### PR TITLE
Added Loader to yaml loader

### DIFF
--- a/simexpal/util.py
+++ b/simexpal/util.py
@@ -57,7 +57,7 @@ def touch(path):
 
 def read_setup_file(setup_file):
 	with open(setup_file, 'r') as f:
-		setup_dict = yaml.load(f)
+		setup_dict = yaml.load(f, Loader=yaml.Loader)
 	return setup_dict
 
 def validate_setup_file(setup_file):


### PR DESCRIPTION
Yaml deprecated the `loader` function without specifying a `Loader`; this specifies the `yaml.Loader` to read the setup file.