### PR TITLE
Persistent launchers and additional Slurm features

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -351,3 +351,29 @@ Once the build process is finished, the experiments can be started as usual.
     ----------
     TODO
 
+Launchers / Support for Batch Schedulers
+----------------------------------------
+
+To submit experiments to a batch scheduler, simexpal allows you to define "launchers".
+A launcher specifies where and how simexpal should submit experiments. If no launcher
+(not even a default launcher or ``--launch-through``) is specified,
+simexpal launches experiments on the local machine.
+
+Launchers are defined in a file ``~/.simexpal/launchers.yml``. For example,
+to submit jobs to the Slurm partition ``fat-nodes``, a launcher configuration
+could look like this:
+
+.. code-block:: YAML
+
+    launchers:
+      - name: local-cluster
+        default: true
+        scheduler: slurm
+        queue: fat-nodes
+
+When launching experiments using ``simex experiments launch``, you can specify
+the ``--launcher`` option (e.g., ``simex experiments launch --launcher local-cluster``)
+to select a certain launcher. Note that the ``default: true`` attribute
+of a launcher overrides the default behavior of launching on the local machine
+(hence, there can only be one launcher with ``default: true``).
+

--- a/scripts/simex
+++ b/scripts/simex
@@ -268,12 +268,26 @@ def do_experiments_launch(args):
 		else:
 			raise RuntimeError('Unknown scheduler {}'.format(scheduler))
 
+	lf_yml = None
+	default_yml = None
+	with open(os.path.expanduser('~/.simexpal/launchers.yml'), 'r') as f:
+		lf_yml = yaml.load(f, Loader=yaml.Loader)
+
+		# Find the default launcher.
+		# TODO: Raise some "syntax error" exception here.
+		assert 'launchers' in lf_yml
+		default_yml_list = [default_yml for default_yml in lf_yml['launchers']
+				if 'default' in default_yml and default_yml['default']]
+
+		if len(default_yml_list) > 1:
+			raise RuntimeError('Default launcher is not unique')
+		if default_yml_list:
+			default_yml = default_yml_list[0]
+
 	if args.launcher:
 		assert not args.launch_through
 
-		with open(os.path.expanduser('~/.simexpal/launchers.yml'), 'r') as f:
-			lf_yml = yaml.load(f, Loader=yaml.Loader)
-
+		# Find the specified launcher.
 		# TODO: Raise some "syntax error" exception here.
 		assert 'launchers' in lf_yml
 		info_yml_list = [info_yml for info_yml in lf_yml['launchers']
@@ -285,12 +299,23 @@ def do_experiments_launch(args):
 			raise RuntimeError('Launcher {} is not unique'.format(args.launcher))
 		info_yml = info_yml_list[0]
 
-		launcher = create_launcher(info_yml['scheduler'])
-	else:
-		launcher = create_launcher(
-			scheduler=args.launch_through or 'fork',
+		launcher = create_launcher(info_yml['scheduler'],
+			queue=info_yml['queue'] if 'queue' in info_yml else None
+		)
+	elif args.launch_through:
+		assert not args.launcher
+
+		launcher = create_launcher(args.launch_through,
 			queue=args.queue
 		)
+	elif default_yml:
+		# Fallback: use the default launcher.
+		launcher = create_launcher(default_yml['scheduler'],
+			queue=default_yml['queue'] if 'queue' in default_yml else None
+		)
+	else:
+		# Final fallback: use the the fork()-based launcher.
+		launcher = create_launcher(scheduler='fork')
 
 	# If the launcher supports submit_multiple, we prefer that.
 	try:

--- a/scripts/simex
+++ b/scripts/simex
@@ -255,14 +255,14 @@ def do_experiments_launch(args):
 			continue
 		sel.append(run)
 
-	if args.launcher == 'slurm':
+	if args.launch_through == 'slurm':
 		launcher = extl.launch.slurm.SlurmLauncher(args.queue)
-	elif args.launcher == 'sge':
+	elif args.launch_through == 'sge':
 		launcher = extl.launch.sge.SgeLauncher(args.queue)
-	elif args.launcher == 'queue':
+	elif args.launch_through == 'queue':
 		launcher = extl.launch.queue.QueueLauncher()
 	else:
-		assert args.launcher == 'fork'
+		assert args.launch_through == 'fork'
 		launcher = extl.launch.fork.ForkLauncher()
 
 	# If the launcher supports submit_multiple, we prefer that.
@@ -278,7 +278,7 @@ def do_experiments_launch(args):
 experiments_launch_parser = experiments_subcmds.add_parser('launch',
 		parents=[run_selection_parser])
 experiments_launch_parser.set_defaults(cmd=do_experiments_launch)
-experiments_launch_parser.add_argument('--launcher', choices=['fork', 'queue', 'slurm', 'sge'],
+experiments_launch_parser.add_argument('--launch-through', choices=['fork', 'queue', 'slurm', 'sge'],
 		default='fork')
 experiments_launch_parser.add_argument('--queue', type=str)
 

--- a/scripts/simex
+++ b/scripts/simex
@@ -255,15 +255,42 @@ def do_experiments_launch(args):
 			continue
 		sel.append(run)
 
-	if args.launch_through == 'slurm':
-		launcher = extl.launch.slurm.SlurmLauncher(args.queue)
-	elif args.launch_through == 'sge':
-		launcher = extl.launch.sge.SgeLauncher(args.queue)
-	elif args.launch_through == 'queue':
-		launcher = extl.launch.queue.QueueLauncher()
+	launcher = None
+	def create_launcher(scheduler, queue=None):
+		if scheduler == 'slurm':
+			return extl.launch.slurm.SlurmLauncher(queue)
+		elif scheduler == 'sge':
+			return extl.launch.sge.SgeLauncher(queue)
+		elif scheduler == 'queue':
+			return extl.launch.queue.QueueLauncher()
+		elif scheduler == 'fork':
+			return extl.launch.fork.ForkLauncher()
+		else:
+			raise RuntimeError('Unknown scheduler {}'.format(scheduler))
+
+	if args.launcher:
+		assert not args.launch_through
+
+		with open(os.path.expanduser('~/.simexpal/launchers.yml'), 'r') as f:
+			lf_yml = yaml.load(f, Loader=yaml.Loader)
+
+		# TODO: Raise some "syntax error" exception here.
+		assert 'launchers' in lf_yml
+		info_yml_list = [info_yml for info_yml in lf_yml['launchers']
+				if info_yml['name'] == args.launcher]
+
+		if not info_yml_list:
+			raise RuntimeError('There is no launcher named {}'.format(args.launcher))
+		if len(info_yml_list) > 1:
+			raise RuntimeError('Launcher {} is not unique'.format(args.launcher))
+		info_yml = info_yml_list[0]
+
+		launcher = create_launcher(info_yml['scheduler'])
 	else:
-		assert args.launch_through == 'fork'
-		launcher = extl.launch.fork.ForkLauncher()
+		launcher = create_launcher(
+			scheduler=args.launch_through or 'fork',
+			queue=args.queue
+		)
 
 	# If the launcher supports submit_multiple, we prefer that.
 	try:
@@ -278,8 +305,8 @@ def do_experiments_launch(args):
 experiments_launch_parser = experiments_subcmds.add_parser('launch',
 		parents=[run_selection_parser])
 experiments_launch_parser.set_defaults(cmd=do_experiments_launch)
-experiments_launch_parser.add_argument('--launch-through', choices=['fork', 'queue', 'slurm', 'sge'],
-		default='fork')
+experiments_launch_parser.add_argument('--launcher', type=str)
+experiments_launch_parser.add_argument('--launch-through', choices=['fork', 'queue', 'slurm', 'sge'])
 experiments_launch_parser.add_argument('--queue', type=str)
 
 def do_experiments_purge(args):

--- a/scripts/simex
+++ b/scripts/simex
@@ -330,8 +330,10 @@ def do_experiments_launch(args):
 experiments_launch_parser = experiments_subcmds.add_parser('launch',
 		parents=[run_selection_parser])
 experiments_launch_parser.set_defaults(cmd=do_experiments_launch)
-experiments_launch_parser.add_argument('--launcher', type=str)
-experiments_launch_parser.add_argument('--launch-through', choices=['fork', 'queue', 'slurm', 'sge'])
+experiments_launch_mechanism = experiments_launch_parser.add_mutually_exclusive_group()
+experiments_launch_mechanism.add_argument('--launcher', type=str)
+experiments_launch_mechanism.add_argument('--launch-through',
+		choices=['fork', 'queue', 'slurm', 'sge'])
 experiments_launch_parser.add_argument('--queue', type=str)
 
 def do_experiments_purge(args):

--- a/simexpal/launch/slurm.py
+++ b/simexpal/launch/slurm.py
@@ -1,4 +1,5 @@
 
+import collections
 import os
 import subprocess
 import sys
@@ -17,12 +18,16 @@ class SlurmLauncher(common.Launcher):
 		self.queue = queue
 
 	def submit(self, cfg, run):
-		self._do_submit(cfg, [run])
+		self._do_submit(cfg, run.experiment, [run])
 
 	def submit_multiple(self, cfg, runs):
-		self._do_submit(cfg, runs)
+		groups = collections.defaultdict(list)
+		for run in runs:
+			groups[run.experiment].append(run)
+		for grp_exp, grp_runs in groups.items():
+			self._do_submit(cfg, grp_exp, grp_runs)
 
-	def _do_submit(self, cfg, runs):
+	def _do_submit(self, cfg, experiment, runs):
 		util.try_mkdir(os.path.join(cfg.basedir, 'aux'))
 		util.try_mkdir(os.path.join(cfg.basedir, 'aux/_slurm'))
 

--- a/simexpal/launch/slurm.py
+++ b/simexpal/launch/slurm.py
@@ -76,6 +76,8 @@ class SlurmLauncher(common.Launcher):
 		# Build the sbatch command to run the script.
 		# TODO: Support multiple queues
 		sbatch_args = ['sbatch']
+		if self.queue:
+			sbatch_args += ['-p', self.queue]
 		if ps and ps['num_nodes']:
 			sbatch_args += ['-N', str(ps['num_nodes'])]
 		if ps and ps['procs_per_node']:
@@ -91,8 +93,12 @@ class SlurmLauncher(common.Launcher):
 
 		# Finally start the run.
 		for run in locked:
-			print("Submitting experiment '{}', instance '{}' to slurm queue '{}'".format(
-					run.experiment.name, run.instance.filename, '?'))
+			if self.queue:
+				print("Submitting experiment '{}', instance '{}' to slurm partition '{}'".format(
+						run.experiment.name, run.instance.filename, self.queue))
+			else:
+				print("Submitting experiment '{}', instance '{}' to default slurm partition".format(
+						run.experiment.name, run.instance.filename))
 
 		process = subprocess.Popen(sbatch_args, stdin=subprocess.PIPE);
 		process.communicate(sbatch_script.encode()) # Assume UTF-8 encoding here.

--- a/simexpal/launch/slurm.py
+++ b/simexpal/launch/slurm.py
@@ -70,9 +70,18 @@ class SlurmLauncher(common.Launcher):
 
 		sbatch_script = util.expand_at_params(script_template, substitute)
 
+		ps = experiment.effective_process_settings
+		ts = experiment.effective_thread_settings
+
 		# Build the sbatch command to run the script.
 		# TODO: Support multiple queues
 		sbatch_args = ['sbatch']
+		if ps and ps['num_nodes']:
+			sbatch_args += ['-N', str(ps['num_nodes'])]
+		if ps and ps['procs_per_node']:
+			sbatch_args += ['--ntasks-per-node', str(ps['procs_per_node'])]
+		if ts and ts['num_threads']:
+			sbatch_args += ['-c', str(ts['num_threads'])]
 		log_pattern = '%A-%a' if use_array else '%A'
 		sbatch_args.extend(['-o', os.path.join(cfg.basedir, 'aux/_slurm/' + log_pattern + '.out'),
 				'-e', os.path.join(cfg.basedir, 'aux/_slurm/' + log_pattern + '.err')])


### PR DESCRIPTION
This PR reworks `simexpal e launch` to support "persistent" launchers in `~/.simexpal/launchers.yml`. The last commit documents this feature, I refer to that commit for further description of the feature:
https://github.com/avdgrinten/simexpal/commit/f6fae668bca31a5a9b9120d9f0f8cc7d14b7fff3

In addition to persistent launchers, the PR adds the following features:
- Schedulers can still be directly selected at the command line, using `--launch-through`.
- Slurm partitions work as expected. In `launchers.yml`, they can be specified using `queue:`.
- Parallel experiments (e.g., multi-node / MPI or multi-threaded experiments) can be submitted using the new `num_nodes` / `procs_per_node` attributes (to control the number of nodes and processes) and `num_threads` (to control the number of threads). The attributes can be applied to experiments or to variants in `experiments.yml`. (This feature still needs more documentation.)