### PR TITLE
Feature/additional slurm args

### DIFF
--- a/scripts/simex
+++ b/scripts/simex
@@ -249,12 +249,7 @@ def do_experiments_list(args, as_default_subcmd=False):
 			print(colors['green'], end='')
 		elif status == 'timeout' or status == 'killed' or status == 'failed':
 			print(colors['red'], end='')
-		name = exp.name
-		if exp.variation:
-			name += ' ~ ' + ', '.join([variant.name for variant in exp.variation])
-		if exp.revision:
-			name += ' @ ' + exp.revision.name
-		print('{:45.45} {:35.35} [{}] {}'.format(name, instance, run.repetition, status))
+		print('{:45.45} {:35.35} [{}] {}'.format(exp.display_name, instance, run.repetition, status))
 		print(colors['reset'], end='')
 
 experiments_list_parser = experiments_subcmds.add_parser('list',

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -633,6 +633,10 @@ class ExperimentInfo:
 	def thread_settings(self):
 		return extract_thread_settings(self._exp_yml)
 
+	@property
+	def slurm_args(self):
+		return self._exp_yml.get('slurm_args',[])
+
 class Experiment:
 	"""
 	Represents an experiment (see below).

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -694,6 +694,15 @@ class Experiment:
 			s = vs
 		return s or self.info.thread_settings
 
+	@property
+	def display_name(self):
+		display_name = self.name
+		if self.variation:
+			display_name += ' ~ ' + ', '.join([variant.name for variant in self.variation])
+		if self.revision:
+			display_name += ' @ ' + self.revision.name
+		return display_name
+
 class Run:
 	def __init__(self, cfg, experiment, instance, repetition):
 		self._cfg = cfg

--- a/simexpal/launch/slurm.py
+++ b/simexpal/launch/slurm.py
@@ -75,7 +75,7 @@ class SlurmLauncher(common.Launcher):
 
 		# Build the sbatch command to run the script.
 		# TODO: Support multiple queues
-		sbatch_args = ['sbatch']
+		sbatch_args = ['sbatch', '-J', experiment.display_name]
 		if self.queue:
 			sbatch_args += ['-p', self.queue]
 		if ps and ps['num_nodes']:
@@ -90,6 +90,10 @@ class SlurmLauncher(common.Launcher):
 
 		if use_array:
 			sbatch_args.append('--array=0-' + str(len(locked) - 1))
+
+		# Add custom sbatch parameters of the user.
+		slurm_args = util.ensure_list_type(experiment.info.slurm_args)
+		sbatch_args.extend(slurm_args)
 
 		# Finally start the run.
 		for run in locked:


### PR DESCRIPTION
This PR adds functionality to support user-defined slurm parameters in the experiments.yml for each experiment. If the user provides parameters that simexpal sets, e.g. the Jobname or the output file, the user arguments will be prioritized.

I could change it, so that simexpal's parameters get priority in case we need that.