### PR TITLE
Feature/multiple input files

### DIFF
--- a/scripts/simex
+++ b/scripts/simex
@@ -43,7 +43,7 @@ def cli_selects_run(args, run):
 		if args.experiment != run.experiment.name:
 			return False
 	if args.instance is not None:
-		if args.instance != run.instance.filename:
+		if args.instance != run.instance.shortname:
 			return False
 	if args.revision is not None:
 		if (run.experiment.revision is None
@@ -53,7 +53,7 @@ def cli_selects_run(args, run):
 		if args.instset not in run.instance.instsets:
 			return False
 	if args.run is not None:
-		if args.run != run.experiment.name + '/' + run.instance.filename:
+		if args.run != run.experiment.name + '/' + run.instance.shortname:
 			return False
 	if args.failed:
 		if not run.get_status().is_negative:
@@ -115,7 +115,7 @@ def do_instances_list(args):
 			print(colors['green'], end='')
 		else:
 			print(colors['red'], end='')
-		print(instance.filename, end='')
+		print(instance.shortname, end='')
 		print(colors['reset'])
 
 instances_list_parser = instances_subcmds.add_parser('list')
@@ -140,12 +140,15 @@ def do_instances_process(args):
 		if not inst.check_available():
 			print("Skipping unavailable instance '{}'".format(inst.shortname))
 			continue
+		if len(inst.filenames) > 1:
+			print("Skipping instance '{}' as it does not have a unique filename".format(inst.shortname))
+			continue
 		if os.access(os.path.join(cfg.instance_dir(), inst.shortname + '.info'), os.F_OK):
 			continue
 
 		print("Processing instance '{}'".format(inst.shortname))
 		with open(os.path.join(cfg.instance_dir(), inst.shortname + '.info.tmp'), 'w') as f:
-			extl.util.compute_network_size(os.path.join(cfg.instance_dir(), inst.filename), f)
+			extl.util.compute_network_size(os.path.join(cfg.instance_dir(), inst.unique_filename), f)
 		os.rename(os.path.join(cfg.instance_dir(), inst.shortname + '.info.tmp'),
 				os.path.join(cfg.instance_dir(), inst.shortname + '.info'))
 
@@ -204,7 +207,7 @@ def do_experiments_list(args, as_default_subcmd=False):
 	print('{:45.45} {:35.35} {}'.format('Experiment', 'Instance', 'Status'))
 	print('{:45.45} {:35.35} {}'.format('----------', '--------', '------'))
 	for run in selection:
-		exp, instance, status = (run.experiment, run.instance.filename, run.get_status())
+		exp, instance, status = (run.experiment, run.instance.shortname, run.get_status())
 
 		if status.is_neutral:
 			print(colors['yellow'], end='')
@@ -226,7 +229,7 @@ def do_experiments_launch(args):
 	for run in select_runs_from_cli(cfg, args):
 		if not run.instance.check_available():
 			print("Skipping run {}/{}[{}] as instance is not available".format(
-					run.experiment.name, run.instance.filename, run.repetition))
+					run.experiment.name, run.instance.shortname, run.repetition))
 			continue
 		sel.append(run)
 
@@ -326,7 +329,7 @@ def do_experiments_purge(args):
 		return
 	else:
 		for run in select_runs_from_cli(cfg, args, default_all=False):
-			(exp, instance) = (run.experiment, run.instance.filename)
+			(exp, instance) = (run.experiment, run.instance.shortname)
 
 			if args.f:
 				print("Purging experiment '{}', instance '{}' [{}]".format(
@@ -378,7 +381,7 @@ def do_experiments_print_output(args):
 	else:
 		for run in select_runs_from_cli(cfg, args, default_all=False):
 			print('Experiment: {}'.format(run.experiment.name))
-			print('Instance: {}'.format(run.instance.filename))
+			print('Instance: {}'.format(run.instance.shortname))
 			print('Output:\n\n{}\n'.format(util.read_file(run.output_file_path('out'))))
 			print('Error Output:\n\n{}\n'.format(util.read_file(run.aux_file_path('stderr'))))
 
@@ -474,14 +477,14 @@ def do_invoke(args, basedir=None):
 
 				if run.experiment.name != ent_yml['experiment']:
 					continue
-				if run.instance.filename != ent_yml['instance']:
+				if run.instance.shortname != ent_yml['instance']:
 					continue
 				if run.repetition != ent_yml['repetition']:
 					continue
 			else:
 				if run.experiment.name != args.experiment:
 					continue
-				if run.instance.filename != args.instance:
+				if run.instance.shortname != args.instance:
 					continue
 				if run.repetition != args.repetition:
 					continue
@@ -489,7 +492,7 @@ def do_invoke(args, basedir=None):
 
 		for run in sel:
 			if args.n:
-				print("Would launch {}/{}[{}]".format(run.experiment.name, run.instance.filename,
+				print("Would launch {}/{}[{}]".format(run.experiment.name, run.instance.shortname,
 						run.repetition))
 			else:
 				manifest = extl.launch.common.compile_manifest(run)

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -442,6 +442,12 @@ class Instance:
 		else:
 			return [self.yml_name]
 
+	@property
+	def unique_filename(self):
+		if len(self.filenames) > 1:
+			raise RuntimeError("The instance '{}' does not have a unique filename.".format(self.yml_name))
+		return self.filenames[0]
+
 	def check_available(self):
 		for file in self.filenames:
 			if not os.path.isfile(os.path.join(self._cfg.instance_dir(), file)):

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -123,8 +123,8 @@ class Config:
 		def construct_instances():
 			if 'instances' in self.yml:
 				for inst_yml in self.yml['instances']:
-					for item in inst_yml['items']:
-						yield Instance(self, item, inst_yml)
+					for idx, item in enumerate(inst_yml['items']):
+						yield Instance(self, item, inst_yml, idx)
 
 		def construct_variants():
 			if 'variants' in self.yml:
@@ -376,10 +376,11 @@ class Config:
 class Instance:
 	"""Represents a single instance"""
 
-	def __init__(self, cfg, filename, inst_yml):
+	def __init__(self, cfg, filename, inst_yml, index):
 		self._cfg = cfg
 		self.filename = filename
 		self._inst_yml = inst_yml
+		self.index = index
 
 	@property
 	def config(self):

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -392,6 +392,15 @@ class Instance:
 		return self._inst_yml['items'][self.index]
 
 	@property
+	def has_multi_ext(self):
+		return 'extensions' in self._inst_yml
+
+	@property
+	def extensions(self):
+		assert self.has_multi_ext
+		return self._inst_yml['extensions']
+
+	@property
 	def config(self):
 		return self._cfg
 

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -28,18 +28,16 @@ def get_output_subdir(base_dir, experiment, variation, revision):
 	return os.path.join(base_dir, 'output', experiment + var + rev)
 
 def get_aux_file_name(ext, instance, repetition):
-	(fbase, _) = os.path.splitext(instance)
 	rep = ''
 	if repetition > 0:
 		rep = '[{}]'.format(repetition)
-	return fbase + '.' + ext + rep
+	return instance + '.' + ext + rep
 
 def get_output_file_name(ext, instance, repetition):
-	(fbase, _) = os.path.splitext(instance)
 	rep = ''
 	if repetition > 0:
 		rep = '[{}]'.format(repetition)
-	return fbase + '.' + ext + rep
+	return instance + '.' + ext + rep
 
 class MatrixScope:
 	@staticmethod

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -383,6 +383,15 @@ class Instance:
 		self.index = index
 
 	@property
+	def yml_name(self):
+		if isinstance(self._inst_yml['items'][self.index], dict):
+			assert 'name' in self._inst_yml['items'][self.index]
+
+			return self._inst_yml['items'][self.index]['name']
+
+		return self._inst_yml['items'][self.index]
+
+	@property
 	def config(self):
 		return self._cfg
 

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -131,21 +131,31 @@ class Config:
 						yield Variant(self, axis_yml['axis'], variant_yml)
 
 		for inst in sorted(construct_instances(), key=lambda inst: inst.shortname):
+			if inst.shortname in self._insts:
+				raise RuntimeError("The instance name '{}' is ambiguous".format(inst.shortname))
 			self._insts[inst.shortname] = inst
 
 		if 'builds' in self.yml:
 			for build_yml in sorted(self.yml['builds'], key=lambda y: y['name']):
+				if build_yml['name'] in self._build_infos:
+					raise RuntimeError("The build name '{}' is ambiguous".format(build_yml['name']))
 				self._build_infos[build_yml['name']] = BuildInfo(self, build_yml)
 
 		if 'revisions' in self.yml:
 			for revision_yml in sorted(self.yml['revisions'], key=lambda y: y['name']):
+				if revision_yml['name'] in self._revisions:
+					raise RuntimeError("The revision name '{}' is ambiguous".format(revision_yml['name']))
 				self._revisions[revision_yml['name']] = Revision(self, revision_yml)
 
 		for variant in sorted(construct_variants(), key=lambda variant: variant.name):
+			if variant.name in self._variants:
+				raise RuntimeError("The variant name '{}' is ambiguous".format(variant.name))
 			self._variants[variant.name] = variant
 
 		if 'experiments' in self.yml:
 			for exp_yml in sorted(self.yml['experiments'], key=lambda y: y['name']):
+				if exp_yml['name'] in self._exp_infos:
+					raise RuntimeError("The experiment name '{}' is ambiguous".format(exp_yml['name']))
 				self._exp_infos[exp_yml['name']] = ExperimentInfo(self, exp_yml)
 
 	def instance_dir(self):

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -443,7 +443,10 @@ class Instance:
 			return [self.yml_name]
 
 	def check_available(self):
-		return os.path.isfile(os.path.join(self._cfg.instance_dir(), self.filename))
+		for file in self.filenames:
+			if not os.path.isfile(os.path.join(self._cfg.instance_dir(), file)):
+				return False
+		return True
 
 	def install(self):
 		if self.check_available():

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -396,6 +396,12 @@ class Instance:
 		return 'extensions' in self._inst_yml
 
 	@property
+	def has_multi_files(self):
+		if isinstance(self._inst_yml['items'][self.index], dict):
+			return 'files' in self._inst_yml['items'][self.index]
+		return False
+
+	@property
 	def extensions(self):
 		assert self.has_multi_ext
 		return self._inst_yml['extensions']

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -433,6 +433,15 @@ class Instance:
 			return None
 		return self._inst_yml['repo']
 
+	@property
+	def filenames(self):
+		if self.has_multi_ext:
+			return [self.yml_name + '.' + ext for ext in self._inst_yml['extensions']]
+		elif self.has_multi_files:
+			return [file for file in self._inst_yml['items'][self.index]['files']]
+		else:
+			return [self.yml_name]
+
 	def check_available(self):
 		return os.path.isfile(os.path.join(self._cfg.instance_dir(), self.filename))
 

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -121,8 +121,8 @@ class Config:
 		def construct_instances():
 			if 'instances' in self.yml:
 				for inst_yml in self.yml['instances']:
-					for idx, item in enumerate(inst_yml['items']):
-						yield Instance(self, item, inst_yml, idx)
+					for idx in range(len(inst_yml['items'])):
+						yield Instance(self, inst_yml, idx)
 
 		def construct_variants():
 			if 'variants' in self.yml:
@@ -374,11 +374,19 @@ class Config:
 class Instance:
 	"""Represents a single instance"""
 
-	def __init__(self, cfg, filename, inst_yml, index):
+	def __init__(self, cfg, inst_yml, index):
 		self._cfg = cfg
-		self.filename = filename
 		self._inst_yml = inst_yml
 		self.index = index
+
+	@property
+	def filename(self):
+		import warnings
+		warnings.simplefilter(action='default', category=DeprecationWarning)
+		msg = "The 'Instance.filename' attribute is deprecated and will be removed in future versions."
+		warnings.warn(msg, DeprecationWarning)
+
+		return self.filenames[0]
 
 	@property
 	def yml_name(self):

--- a/simexpal/launch/common.py
+++ b/simexpal/launch/common.py
@@ -68,6 +68,10 @@ class RunManifest:
 		return self.yml['instance']
 
 	@property
+	def instance_yml_name(self):
+		return self.yml['instance_filename']
+
+	@property
 	def experiment(self):
 		return self.yml['experiment']
 
@@ -206,7 +210,8 @@ def compile_manifest(run):
 		'experiment': exp.name,
 		'variants': variants_yml,
 		'revision': exp.revision.name if exp.revision else None,
-		'instance': run.instance.filename,
+		'instance': run.instance.shortname,
+		'instance_filename': run.instance.yml_name,
 		'repetition': run.repetition,
 		'builds': builds_yml,
 		'args': exp.info._exp_yml['args'],
@@ -234,7 +239,7 @@ def invoke_run(manifest):
 
 	def substitute(p):
 		if p == 'INSTANCE':
-			return manifest.instance_dir + '/' + manifest.instance
+			return manifest.instance_dir + '/' + manifest.instance_yml_name
 		elif p == 'REPETITION':
 			return str(manifest.repetition)
 		elif p == 'OUTPUT':

--- a/simexpal/launch/common.py
+++ b/simexpal/launch/common.py
@@ -14,11 +14,10 @@ class Launcher:
 	pass
 
 def lock_run(run):
-	(exp, instance) = (run.experiment, run.instance.filename)
 	util.try_mkdir(os.path.join(run.config.basedir, 'aux'))
 	util.try_mkdir(os.path.join(run.config.basedir, 'output'))
-	util.try_mkdir(exp.aux_subdir)
-	util.try_mkdir(exp.output_subdir)
+	util.try_mkdir(run.experiment.aux_subdir)
+	util.try_mkdir(run.experiment.output_subdir)
 
 	# We will try to launch the experiment.
 	# First, create a .lock file. If that is successful, we are the process that
@@ -37,7 +36,6 @@ def lock_run(run):
 	return True
 
 def create_run_file(run):
-	(exp, instance) = (run.experiment, run.instance.filename)
 
 	# Create the .run file. This signals that the run has been submitted.
 	with open(run.aux_file_path('run.tmp'), "w") as f:

--- a/simexpal/launch/fork.py
+++ b/simexpal/launch/fork.py
@@ -8,7 +8,7 @@ class ForkLauncher(common.Launcher):
 		common.create_run_file(run)
 
 		print("Launching experiment '{}', instance '{}' on local machine".format(
-				run.experiment.name, run.instance.filename))
+				run.experiment.name, run.instance.shortname))
 		manifest = common.compile_manifest(run)
 		common.invoke_run(manifest)
 

--- a/simexpal/launch/queue.py
+++ b/simexpal/launch/queue.py
@@ -13,7 +13,7 @@ class QueueLauncher(common.Launcher):
 		common.create_run_file(run)
 
 		print("Launching experiment '{}', instance '{}' on local machine".format(
-				run.experiment.name, run.instance.filename))
+				run.experiment.name, run.instance.shortname))
 
 		queuesock.sendrecv({
 			'action': 'launch',

--- a/simexpal/launch/sge.py
+++ b/simexpal/launch/sge.py
@@ -36,10 +36,10 @@ class SgeLauncher(common.Launcher):
 				return
 			locked = [r]
 			print("Launching experiment '{}', instance '{}' on SGE queue '{}'".format(
-					r.experiment.name, r.instance.filename, self.queue))
+					r.experiment.name, r.instance.shortname, self.queue))
 
 			invoke_args.extend(['--experiment', r.experiment.name,
-					'--instance', r.instance.filename,
+					'--instance', r.instance.shortname,
 					'--repetition', str(r.repetition)])
 		else:
 			locked = [ ]
@@ -47,7 +47,7 @@ class SgeLauncher(common.Launcher):
 				if not common.lock_run(run):
 					continue
 				print("Launching experiment '{}', instance '{}' on SGE queue '{}'".format(
-						run.experiment.name, run.instance.filename, self.queue))
+						run.experiment.name, run.instance.shortname, self.queue))
 				locked.append(run)
 
 			if not locked:
@@ -55,7 +55,7 @@ class SgeLauncher(common.Launcher):
 
 			spec_dict = {'array': [
 				{'experiment': run.experiment.name,
-					'instance': run.instance.filename,
+					'instance': run.instance.shortname,
 					'repetition': run.repetition}
 				for run in locked
 			]}

--- a/simexpal/launch/slurm.py
+++ b/simexpal/launch/slurm.py
@@ -99,10 +99,10 @@ class SlurmLauncher(common.Launcher):
 		for run in locked:
 			if self.queue:
 				print("Submitting experiment '{}', instance '{}' to slurm partition '{}'".format(
-						run.experiment.name, run.instance.filename, self.queue))
+						run.experiment.name, run.instance.shortname, self.queue))
 			else:
 				print("Submitting experiment '{}', instance '{}' to default slurm partition".format(
-						run.experiment.name, run.instance.filename))
+						run.experiment.name, run.instance.shortname))
 
 		process = subprocess.Popen(sbatch_args, stdin=subprocess.PIPE);
 		process.communicate(sbatch_script.encode()) # Assume UTF-8 encoding here.

--- a/simexpal/util.py
+++ b/simexpal/util.py
@@ -25,11 +25,11 @@ def expand_at_params(s, fn, listfn=None):
 						seq.extend(result)
 						continue
 
-			seq.append(re.sub(r'@(\w+)@', subfn, item))
+			seq.append(re.sub(r'@(\w+(:[^@]+)?)@', subfn, item))
 		return seq
 	else:
 		assert isinstance(s, str)
-		return re.sub(r'@(\w+)@', subfn, s)
+		return re.sub(r'@(\w+(:[^@]+)?)@', subfn, s)
 
 def try_mkdir(path):
 	try:


### PR DESCRIPTION
This PR contains the following:
* Refactoring of 'Instance.filename' with 'Instance_get_unique_name()' and marking 'Instance.filename' as deprecated
* Added support for experiments with multiple input files