### PR TITLE
Minor changes

### DIFF
--- a/scripts/simex
+++ b/scripts/simex
@@ -286,7 +286,7 @@ def do_experiments_launch(args):
 		file_path = os.path.expanduser('~/.simexpal/launchers.yml')
 		f = open(file_path, 'r')
 	except FileNotFoundError:
-		print("No launcher was specified in {}.".format(file_path))
+		pass
 	else:
 		with f:
 			lf_yml = yaml.load(f, Loader=yaml.Loader)

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -482,8 +482,12 @@ class BuildInfo:
 	@property
 	def requirements(self):
 		if 'requires' in self._build_yml:
-			for name in self._build_yml['requires']:
-				yield name
+			if isinstance(self._build_yml['requires'], list):
+				for name in self._build_yml['requires']:
+					yield name
+			else:
+				assert isinstance(self._build_yml['requires'], str)
+				yield self._build_yml['requires']
 
 	def traverse_requirements(self):
 		# Perform a DFS to discover all recursively required builds.

--- a/simexpal/launch/common.py
+++ b/simexpal/launch/common.py
@@ -185,7 +185,7 @@ def compile_manifest(run):
 				environ[k] = str(v)
 		variants_yml.append({
 			'name': variant.name,
-			'extra_args': variant.variant_yml['extra_args'],
+			'extra_args': variant.variant_yml.get('extra_args', []),
 			'environ': environ
 		})
 
@@ -212,8 +212,8 @@ def compile_manifest(run):
 		'args': exp.info._exp_yml['args'],
 		'timeout': timeout,
 		'environ': environ,
-		'output': exp.info._exp_yml['output'] if 'output' in exp.info._exp_yml else None,
-		'workdir': exp.info._exp_yml['workdir'] if 'workdir' in exp.info._exp_yml else None
+		'output': exp.info._exp_yml.get('output', None),
+		'workdir': exp.info._exp_yml.get('workdir', None)
 	})
 
 def invoke_run(manifest):


### PR DESCRIPTION
This PR contains the following:
* Resolves Issue #22 
* 'extra_args' is not required for variants anymore. Until now you had to have an empty `extra_args` (i.e. `extra_args: []`) in a variant block if you did not want any extra arguments. Now you can leave it out completely.
* If build **X** requires build **Y** you can now write `requires: Y` in the build block of **X** instead of `requires: [Y]`