### PR TITLE
Support development builds

### DIFF
--- a/scripts/simex
+++ b/scripts/simex
@@ -96,6 +96,70 @@ run_selection_parser.add_argument('--failed', action='store_true')
 run_selection_parser.add_argument('--unfinished', action='store_true')
 
 # ---------------------------------------------------------------------------------------
+
+def select_phases_from_cli(args):
+
+	def subsequent_phases(start_phase):
+		return [phase for phase in simexpal.build.Phase if phase >= start_phase]
+
+	if args.recheckout:
+		if not args.f:
+			print("This would delete the local git repository for the build and reclone it. Confirm this action"
+					" by using the '-f' flag.")
+			return []
+		else:
+			return subsequent_phases(simexpal.build.Phase.CHECKOUT)
+	elif args.checkout:
+		if not args.f:
+			print("This would delete the local git repository for the build and reclone it. Confirm this action"
+					" by using the '-f' flag.")
+			return []
+		else:
+			return [simexpal.build.Phase.CHECKOUT]
+	elif args.reregenerate:
+		return subsequent_phases(simexpal.build.Phase.REGENERATE)
+	elif args.regenerate:
+		return [simexpal.build.Phase.REGENERATE]
+	elif args.reconfigure:
+		return subsequent_phases(simexpal.build.Phase.CONFIGURE)
+	elif args.configure:
+		return [simexpal.build.Phase.CONFIGURE]
+	elif args.compile:
+		return [simexpal.build.Phase.COMPILE]
+	elif args.reinstall:
+		return subsequent_phases(simexpal.build.Phase.INSTALL)
+	elif args.install:
+		return [simexpal.build.Phase.INSTALL]
+	else:
+		# This case also includes 'args.recompile == True'
+		return subsequent_phases(simexpal.build.Phase.COMPILE)
+
+phase_selection_parser = argparse.ArgumentParser(add_help=False)
+phase_selection_mechanism = phase_selection_parser.add_mutually_exclusive_group()
+phase_selection_mechanism.add_argument('--recheckout', action='store_true',
+			help='Delete local build git repository, reclone, regenerate, reconfigure, recompile and reinstall it')
+phase_selection_mechanism.add_argument('--checkout', action='store_true',
+			help='Delete local git repository for build and (re-)clone it')
+phase_selection_mechanism.add_argument('--reregenerate', action='store_true',
+			help='Regenerate, reconfigure, recompile and reinstall build')
+phase_selection_mechanism.add_argument('--regenerate', action='store_true',
+			help='(Re-)Regenerate build')
+phase_selection_mechanism.add_argument('--reconfigure', action='store_true',
+			help='Reconfigure, recompile and reinstall build')
+phase_selection_mechanism.add_argument('--configure', action='store_true',
+			help='(Re-)Configure build')
+phase_selection_mechanism.add_argument('--recompile', action='store_true',
+			help='Recompile and reinstall build')
+phase_selection_mechanism.add_argument('--compile', action='store_true',
+			help='(Re-)Compile build')
+phase_selection_mechanism.add_argument('--reinstall', action='store_true',
+			help='Reinstall build')
+phase_selection_mechanism.add_argument('--install', action='store_true',
+			help='(Re-)Install build')
+phase_selection_parser.add_argument('-f', action='store_true',
+			help='Confirm (re-)checkout')
+
+# ---------------------------------------------------------------------------------------
 # Basic commands.
 # ---------------------------------------------------------------------------------------
 

--- a/scripts/simex
+++ b/scripts/simex
@@ -182,7 +182,7 @@ def do_builds_make(args):
 	for revision in cfg.all_revisions():
 		if not revision.is_dev_build:
 			simexpal.build.make_builds(cfg, revision,
-					[build.info for build in cfg.all_builds_for_revision(revision)])
+					[build.info for build in cfg.all_builds_for_revision(revision)], [], [])
 
 builds_make_parser = builds_subcmds.add_parser('make')
 builds_make_parser.set_defaults(cmd=do_builds_make)

--- a/scripts/simex
+++ b/scripts/simex
@@ -253,6 +253,34 @@ builds_make_parser.set_defaults(cmd=do_builds_make)
 
 # ---------------------------------------------------------------------------------------
 
+def do_develop(args):
+	cfg = extl.base.config_for_dir()
+
+	if args.revision is not None:
+		revision = cfg.get_revision(args.revision)
+	else:
+		revision = cfg.get_revision(simexpal.base.DEFAULT_DEV_BUILD_NAME)
+
+	if not revision.is_dev_build:
+		print("Revision '{}' is not a dev-build.".format(revision.name), file=sys.stderr)
+		return
+	else:
+		wanted_phases = select_phases_from_cli(args)
+
+		if not wanted_phases:
+			return
+
+		simexpal.build.make_builds(cfg, revision,
+				[cfg.get_build(build, revision).info for build in args.builds], args.builds, wanted_phases)
+
+dev_builds_parser = main_subcmds.add_parser('develop', help='Build local programs',
+		aliases=['d'], parents=[phase_selection_parser])
+dev_builds_parser.set_defaults(cmd=do_develop)
+dev_builds_parser.add_argument('--revision', type=str)
+dev_builds_parser.add_argument('builds', nargs='+', type=str)
+
+# ---------------------------------------------------------------------------------------
+
 def do_experiments(args):
 	return do_experiments_list(args, as_default_subcmd=True)
 

--- a/scripts/simex
+++ b/scripts/simex
@@ -180,8 +180,9 @@ def do_builds_make(args):
 	cfg = extl.base.config_for_dir()
 
 	for revision in cfg.all_revisions():
-		simexpal.build.make_builds(cfg, revision,
-				[build.info for build in cfg.all_builds_for_revision(revision)])
+		if not revision.is_dev_build:
+			simexpal.build.make_builds(cfg, revision,
+					[build.info for build in cfg.all_builds_for_revision(revision)])
 
 builds_make_parser = builds_subcmds.add_parser('make')
 builds_make_parser.set_defaults(cmd=do_builds_make)

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -624,6 +624,8 @@ class Revision:
 
 	@property
 	def name(self):
+		if 'name' not in self.revision_yml:
+			return DEFAULT_DEV_BUILD_NAME
 		return self.revision_yml['name']
 
 	@property

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -612,6 +612,10 @@ class Revision:
 	def version_for_build(self, build_name):
 		return self.revision_yml['build_version'][build_name]
 
+	@property
+	def is_dev_build(self):
+		return self.revision_yml.get('develop', False)
+
 class Build:
 	def __init__(self, cfg, info, revision):
 		self._cfg = cfg

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -536,10 +536,6 @@ class BuildInfo:
 		return self._build_yml['name']
 
 	@property
-	def repo_dir(self):
-		return os.path.join(self._cfg.basedir, 'builds', self.name + '.repo')
-
-	@property
 	def requirements(self):
 		if 'requires' in self._build_yml:
 			if isinstance(self._build_yml['requires'], list):
@@ -625,6 +621,10 @@ class Build:
 	@property
 	def name(self):
 		return self.info.name
+
+	@property
+	def repo_dir(self):
+		return os.path.join(self._cfg.basedir, 'builds', self.name + '.repo')
 
 	@property
 	def clone_dir(self):

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -9,6 +9,8 @@ import yaml
 from . import instances
 from . import util
 
+DEFAULT_DEV_BUILD_NAME = '_dev'
+
 def get_aux_subdir(base_dir, experiment, variation, revision):
 	var = ''
 	if variation:

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -700,6 +700,25 @@ class Build:
 		rev = self._get_dev_build_suffix()
 		return os.path.join(self._cfg.basedir, 'develop', self.name + rev)
 
+	def is_checked_out(self):
+		if self.revision.is_dev_build:
+			return os.access(os.path.join(self.source_dir, 'checkedout.simexpal'), os.F_OK)
+		return os.access(os.path.join(self.clone_dir, 'checkedout.simexpal'), os.F_OK)
+
+	def is_regenerated(self):
+		if self.revision.is_dev_build:
+			return os.access(os.path.join(self.source_dir, 'regenerated.simexpal'), os.F_OK)
+		return os.access(os.path.join(self.clone_dir, 'regenerated.simexpal'), os.F_OK)
+
+	def is_configured(self):
+		return os.access(os.path.join(self.compile_dir, 'configured.simexpal'), os.F_OK)
+
+	def is_compiled(self):
+		return os.access(os.path.join(self.compile_dir, 'compiled.simexpal'), os.F_OK)
+
+	def is_installed(self):
+		return os.access(os.path.join(self.prefix_dir, 'installed.simexpal'), os.F_OK)
+
 def extract_process_settings(yml):
 	if 'num_nodes' not in yml:
 		return None

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -632,6 +632,12 @@ class Build:
 	def name(self):
 		return self.info.name
 
+	def _get_dev_build_suffix(self):
+		if self.revision.is_default_dev_build:
+			return ''
+		else:
+			return '@' + self.revision.name
+
 	@property
 	def repo_dir(self):
 		return os.path.join(self._cfg.basedir, 'builds', self.name + '.repo')

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -618,6 +618,10 @@ class Revision:
 	def is_dev_build(self):
 		return self.revision_yml.get('develop', False)
 
+	@property
+	def is_default_dev_build(self):
+		return self.name == DEFAULT_DEV_BUILD_NAME
+
 class Build:
 	def __init__(self, cfg, info, revision):
 		self._cfg = cfg

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -649,11 +649,17 @@ class Build:
 
 	@property
 	def compile_dir(self):
+		if self.revision.is_dev_build:
+			rev = self._get_dev_build_suffix()
+			return os.path.join(self._cfg.basedir, 'dev-builds', self.name + rev + '.compile')
 		rev = '@' + self.revision.name
 		return os.path.join(self._cfg.basedir, 'builds', self.name + rev + '.compile')
 
 	@property
 	def prefix_dir(self):
+		if self.revision.is_dev_build:
+			rev = self._get_dev_build_suffix()
+			return os.path.join(self._cfg.basedir, 'dev-builds', self.name + rev)
 		rev = '@' + self.revision.name
 		return os.path.join(self._cfg.basedir, 'builds', self.name + rev)
 

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -657,6 +657,16 @@ class Build:
 		rev = '@' + self.revision.name
 		return os.path.join(self._cfg.basedir, 'builds', self.name + rev)
 
+	@property
+	def source_dir(self):
+		"""
+			dev-builds only have a source directory instead of a repo and clone directory
+		"""
+		assert self.revision.is_dev_build
+
+		rev = self._get_dev_build_suffix()
+		return os.path.join(self._cfg.basedir, 'develop', self.name + rev)
+
 def extract_process_settings(yml):
 	if 'num_nodes' not in yml:
 		return None

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -120,6 +120,10 @@ class Config:
 		self._variants = OrderedDict()
 		self._exp_infos = OrderedDict()
 
+		def check_for_reserved_name(name):
+			if name.startswith('_'):
+				raise RuntimeError(f"Names starting with an underscore are reserved for internal simexpal objects: {name}")
+
 		def construct_instances():
 			if 'instances' in self.yml:
 				for inst_yml in self.yml['instances']:

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -640,10 +640,16 @@ class Build:
 
 	@property
 	def repo_dir(self):
+		# Use the source_dir property for dev-build revisions
+		assert not self.revision.is_dev_build
+
 		return os.path.join(self._cfg.basedir, 'builds', self.name + '.repo')
 
 	@property
 	def clone_dir(self):
+		# Use the source_dir property for dev-build revisions
+		assert not self.revision.is_dev_build
+
 		rev = '@' + self.revision.name
 		return os.path.join(self._cfg.basedir, 'builds', self.name + rev + '.clone')
 

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -133,7 +133,11 @@ class Config:
 		def construct_variants():
 			if 'variants' in self.yml:
 				for axis_yml in self.yml['variants']:
+					check_for_reserved_name(axis_yml['axis'])
+
 					for variant_yml in axis_yml['items']:
+						check_for_reserved_name(variant_yml['name'])
+
 						yield Variant(self, axis_yml['axis'], variant_yml)
 
 		for inst in sorted(construct_instances(), key=lambda inst: inst.shortname):
@@ -143,12 +147,17 @@ class Config:
 
 		if 'builds' in self.yml:
 			for build_yml in sorted(self.yml['builds'], key=lambda y: y['name']):
+				check_for_reserved_name(build_yml['name'])
+
 				if build_yml['name'] in self._build_infos:
 					raise RuntimeError("The build name '{}' is ambiguous".format(build_yml['name']))
 				self._build_infos[build_yml['name']] = BuildInfo(self, build_yml)
 
 		if 'revisions' in self.yml:
 			for revision_yml in sorted(self.yml['revisions'], key=lambda y: y['name']):
+				if 'name' in revision_yml:
+					check_for_reserved_name(revision_yml['name'])
+
 				if revision_yml['name'] in self._revisions:
 					raise RuntimeError("The revision name '{}' is ambiguous".format(revision_yml['name']))
 				self._revisions[revision_yml['name']] = Revision(self, revision_yml)
@@ -160,6 +169,8 @@ class Config:
 
 		if 'experiments' in self.yml:
 			for exp_yml in sorted(self.yml['experiments'], key=lambda y: y['name']):
+				check_for_reserved_name(exp_yml['name'])
+
 				if exp_yml['name'] in self._exp_infos:
 					raise RuntimeError("The experiment name '{}' is ambiguous".format(exp_yml['name']))
 				self._exp_infos[exp_yml['name']] = ExperimentInfo(self, exp_yml)

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -154,13 +154,17 @@ class Config:
 				self._build_infos[build_yml['name']] = BuildInfo(self, build_yml)
 
 		if 'revisions' in self.yml:
-			for revision_yml in sorted(self.yml['revisions'], key=lambda y: y['name']):
+			revision_list = []
+
+			for revision_yml in self.yml['revisions']:
 				if 'name' in revision_yml:
 					check_for_reserved_name(revision_yml['name'])
+				revision_list.append(Revision(self, revision_yml))
 
-				if revision_yml['name'] in self._revisions:
-					raise RuntimeError("The revision name '{}' is ambiguous".format(revision_yml['name']))
-				self._revisions[revision_yml['name']] = Revision(self, revision_yml)
+			for revision in sorted(revision_list, key=lambda y: y.name):
+				if revision.name in self._revisions:
+					raise RuntimeError("The revision name '{}' is ambiguous".format(revision.name))
+				self._revisions[revision.name] = revision
 
 		for variant in sorted(construct_variants(), key=lambda variant: variant.name):
 			if variant.name in self._variants:

--- a/simexpal/build.py
+++ b/simexpal/build.py
@@ -110,15 +110,15 @@ def make_build_in_order(cfg, build):
 	base_environ['PKG_CONFIG_PATH'] = prepend_env('PKG_CONFIG_PATH', pkgconfig_paths)
 
 	done_phases = set()
-	if os.access(os.path.join(build.prefix_dir, 'installed.simexpal'), os.F_OK):
+	if build.is_installed():
 		done_phases.add(Phase.INSTALL)
-	if os.access(os.path.join(build.compile_dir, 'compiled.simexpal'), os.F_OK):
+	if build.is_compiled():
 		done_phases.add(Phase.COMPILE)
-	if os.access(os.path.join(build.compile_dir, 'configured.simexpal'), os.F_OK):
+	if build.is_configured():
 		done_phases.add(Phase.CONFIGURE)
-	if os.access(os.path.join(build.clone_dir, 'regenerated.simexpal'), os.F_OK):
+	if build.is_regenerated():
 		done_phases.add(Phase.REGENERATE)
-	if os.access(os.path.join(build.clone_dir, 'checkedout.simexpal'), os.F_OK):
+	if build.is_checked_out():
 		done_phases.add(Phase.CHECKOUT)
 
 	def want_phase(phase):

--- a/simexpal/build.py
+++ b/simexpal/build.py
@@ -56,6 +56,15 @@ def compute_order(cfg, desired):
 
 	return order
 
+# Determine which phases to run.
+class Phase(IntEnum):
+	NULL = 0
+	CHECKOUT = 1
+	REGENERATE = 2
+	CONFIGURE = 3
+	COMPILE = 4
+	INSTALL = 5
+
 def make_build_in_order(cfg, build):
 	util.try_mkdir('builds/')
 
@@ -99,15 +108,6 @@ def make_build_in_order(cfg, build):
 
 	base_environ = os.environ.copy()
 	base_environ['PKG_CONFIG_PATH'] = prepend_env('PKG_CONFIG_PATH', pkgconfig_paths)
-
-	# Determine which phases to run.
-	class Phase(IntEnum):
-		NULL = 0
-		CHECKOUT = 1
-		REGENERATE = 2
-		CONFIGURE = 3
-		COMPILE = 4
-		INSTALL = 5
 
 	done_phases = set()
 	if os.access(os.path.join(build.prefix_dir, 'installed.simexpal'), os.F_OK):

--- a/simexpal/build.py
+++ b/simexpal/build.py
@@ -168,26 +168,26 @@ def make_build_in_order(cfg, build):
 		#fetch_refspec = ['+refs/tags/' + git_ref + ':' + generic_tag]
 
 		# Create the repository (in an empty state).
-		if not os.access(build.info.repo_dir, os.F_OK):
-			subprocess.check_call(['git', 'init', '-q', '--bare', build.info.repo_dir])
+		if not os.access(build.repo_dir, os.F_OK):
+			subprocess.check_call(['git', 'init', '-q', '--bare', build.repo_dir])
 
 		# Fetch the specified revision if it does not exist already.
-		verify_ref_result = subprocess.call(['git', '--git-dir', build.info.repo_dir,
+		verify_ref_result = subprocess.call(['git', '--git-dir', build.repo_dir,
 				'rev-parse', '-q', '--verify', generic_tag],
 			stdout=subprocess.DEVNULL)
 		if verify_ref_result != 0:
 			# As we create generic_tag, we can add --no-tags here.
-			subprocess.check_call(['git', '--git-dir', build.info.repo_dir,
+			subprocess.check_call(['git', '--git-dir', build.repo_dir,
 					'fetch', '--depth=1', '--no-tags',
 					build.info.git_repo] + fetch_refspec)
 
 		# Prune the existing worktree.
 		util.try_rmtree(build.clone_dir)
-		subprocess.check_call(['git', '--git-dir', build.info.repo_dir,
+		subprocess.check_call(['git', '--git-dir', build.repo_dir,
 				'worktree', 'prune'])
 
 		# Recreate the worktree and check out the specified revision.
-		subprocess.check_call(['git', '--git-dir', build.info.repo_dir,
+		subprocess.check_call(['git', '--git-dir', build.repo_dir,
 				'worktree', 'add', '--detach',
 				build.clone_dir,
 				generic_tag])


### PR DESCRIPTION
This PR contains the following:
* support for dev-build revisions which allow running experiments with programs currently in development (without pushing changes and changing the respective commit hashes in the `experiments.yml`)
* some refactoring regarding status queries of builds and the construction of the `Config._revisions` dictionary
* simexpal now reserves names starting with an underscore (e.g `_dev`). An error is thrown if such names are used in the `experiments.yml`

A typical workflow using dev-builds could look like this:
1. create a revision with the normal syntax
2. add `develop: True` to a revision and remove the commit-hashes (but leave an empty string i.e. `''`, simexpal will pull the latest commit for dev-build revision)
3. use `simex develop <build> --revision <revision_name>` to build the dev-build revision
4. make changes to the program source code in the directory `develop/<build>@<revision_name>.src`
5. use `simex develop <build> --revision <revision_name>` to rebuild it 
6. run experiments
7. repeat steps 3-6 if necessary

It is also possible to remove the `name` attribute for **one** dev-build. Internally simexpal will set the name of this revision to `_dev`.
In most cases there will only be one dev-build and this allows syntactic sugar when working with dev-builds. For example the command `simexpal develop <build>` will do the same as the command `simexpal develop <build> --revision _dev`.
Also for this default dev-build the directories do not have the `@<revision>` suffix.

I will create a PR with a more detailed description of this feature in the future.