### PR TITLE
Bugfix for build process and removal of unused variables

### DIFF
--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -384,7 +384,6 @@ class Config:
 
 		res = [ ]
 		for run in self.discover_all_runs():
-			exp = run.experiment
 			finished = os.access(run.output_file_path('status'), os.F_OK)
 			if not finished:
 				print("Skipping unfinished run {}/{}[{}]".format(run.experiment.name,
@@ -539,7 +538,6 @@ class Instance:
 		os.rename(partial_path + '.post{}'.format(stage), partial_path)
 
 	def run_transform(self, transform, out_path):
-		stage = 0
 		assert transform == 'to_edgelist'
 		instances.convert_to_edgelist(self._inst_yml,
 				self.fullpath, out_path + '.transf1');

--- a/simexpal/build.py
+++ b/simexpal/build.py
@@ -236,7 +236,7 @@ def make_build_in_order(cfg, build, wanted_builds, wanted_phases):
 
 		regenerate_args = util.ensure_list_type(build.info.regenerate)
 		for step_yml in regenerate_args:
-			do_step(step_yml, checkout_dir)
+			do_step(step_yml, default_workdir=checkout_dir)
 		util.touch(os.path.join(checkout_dir, 'regenerated.simexpal'))
 		did_work = True
 

--- a/simexpal/build.py
+++ b/simexpal/build.py
@@ -166,8 +166,6 @@ def make_build_in_order(cfg, build, wanted_builds, wanted_phases):
 			for (var, value) in step_yml['environ'].items():
 				environ[var] = util.expand_at_params(value, substitute)
 
-		shell = None
-		args = None
 		if isinstance(step_yml['args'], list):
 			shell = False
 			args = [util.expand_at_params(arg, substitute) for arg in step_yml['args']]
@@ -226,8 +224,7 @@ def make_build_in_order(cfg, build, wanted_builds, wanted_phases):
 
 		util.touch(os.path.join(checkout_dir, 'checkedout.simexpal'))
 
-		recursive_clone = build.info.recursive_clone
-		if recursive_clone:
+		if build.info.recursive_clone:
 			# Clone submodules recursively
 			subprocess.check_call(['git', 'submodule',
 					'update', '--init', '--recursive'], cwd=checkout_dir)

--- a/simexpal/build.py
+++ b/simexpal/build.py
@@ -118,17 +118,20 @@ def make_build_in_order(cfg, build, wanted_builds, wanted_phases):
 	base_environ = os.environ.copy()
 	base_environ['PKG_CONFIG_PATH'] = prepend_env('PKG_CONFIG_PATH', pkgconfig_paths)
 
+	def skip_phase(phase):
+		return phase > max(wanted_phases)
+
 	done_phases = set()
 	if build.name in wanted_builds:
-		if build.is_installed() and Phase.INSTALL not in wanted_phases:
+		if (build.is_installed() or skip_phase(Phase.INSTALL)) and Phase.INSTALL not in wanted_phases:
 			done_phases.add(Phase.INSTALL)
-		if build.is_compiled() and Phase.COMPILE not in wanted_phases:
+		if (build.is_compiled() or skip_phase(Phase.COMPILE)) and Phase.COMPILE not in wanted_phases:
 			done_phases.add(Phase.COMPILE)
-		if build.is_configured() and Phase.CONFIGURE not in wanted_phases:
+		if (build.is_configured() or skip_phase(Phase.CONFIGURE)) and Phase.CONFIGURE not in wanted_phases:
 			done_phases.add(Phase.CONFIGURE)
-		if build.is_regenerated() and Phase.REGENERATE not in wanted_phases:
+		if (build.is_regenerated() or skip_phase(Phase.REGENERATE)) and Phase.REGENERATE not in wanted_phases:
 			done_phases.add(Phase.REGENERATE)
-		if build.is_checked_out() and Phase.CHECKOUT not in wanted_phases:
+		if (build.is_checked_out() or skip_phase(Phase.CHECKOUT)) and Phase.CHECKOUT not in wanted_phases:
 			done_phases.add(Phase.CHECKOUT)
 	else:
 		if build.is_installed():

--- a/simexpal/instances.py
+++ b/simexpal/instances.py
@@ -74,7 +74,6 @@ def download_instance(inst_yml, instances_dir, filename, partial_path, ext):
 def convert_to_edgelist(inst_yml, in_path, out_path):
 	repo = inst_yml['repo']
 
-	lines = []
 	if repo == 'konect':
 		separator = ' '
 		commentPrefix = '%'

--- a/simexpal/launch/common.py
+++ b/simexpal/launch/common.py
@@ -38,7 +38,7 @@ def lock_run(run):
 def create_run_file(run):
 
 	# Create the .run file. This signals that the run has been submitted.
-	with open(run.aux_file_path('run.tmp'), "w") as f:
+	with open(run.aux_file_path('run.tmp'), "w"):
 		pass
 	os.rename(run.aux_file_path('run.tmp'), run.aux_file_path('run'))
 

--- a/simexpal/util.py
+++ b/simexpal/util.py
@@ -53,7 +53,7 @@ def try_rmtree(path):
 			raise
 
 def touch(path):
-	with open(path, 'w') as f:
+	with open(path, 'w'):
 		pass
 
 did_warn_libyaml = False


### PR DESCRIPTION
This PR contains the following:
* small bug fix regarding the phase handling during the build process
* ~~prefix directories are appended to the PATH environment variable~~
* removal of unused/unnecessary variables
* added `default_workdir` keyword in `do_step()` call in the regenerate phase to make the code consistent with the other phases