### PR TITLE
@-Variables for build-dirs, bugfix and minor refactor

### DIFF
--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -178,7 +178,7 @@ class Config:
 		for build in self.all_builds(): # TODO: Avoid a quadratic blowup.
 			if build.name == name and build.revision == revision:
 				return build
-		raise RuntimeError("Build {} does not exist".format(name))
+		raise RuntimeError("Build '{}' does not exist in revision '{}'".format(name, revision.name))
 
 	def all_variants(self):
 		yield from self._variants.values()

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -206,20 +206,20 @@ class Config:
 			# Helper to find all selected revisions for a given experiment.
 			def revisions_for_experiment(exp_info):
 				if 'use_builds' in exp_info._exp_yml:
-					if [rev.name for rev in selection.revisions] != ['_none']:
+					if selection.revisions is not None:
 						yield from selection.revisions
 					else:
 						yield from self.all_revisions()
 				else:
-					yield Revision(self, {'name': '_none'})
+					yield None
 
 			for exp_info in selection.experiments:
 				yield from itertools.product([exp_info], revisions_for_experiment(exp_info),
 						selection.variations)
 
-		key = lambda x: (x[0].name, x[1].name, [sub_var.name for sub_var in x[2]])
+		key = lambda x: (x[0].name, x[1].name if x[1] is not None else '_none',
+						 [sub_var.name for sub_var in x[2]])
 		for experiment_info, revision, variation in self._expand_matrix(extract, key=key):
-			revision = revision if revision.name != '_none' else None
 			yield Experiment(self, experiment_info, revision, variation)
 
 	def discover_all_runs(self):
@@ -228,12 +228,12 @@ class Config:
 			# Helper to find all selected revisions for a given experiment.
 			def revisions_for_experiment(exp_info):
 				if 'use_builds' in exp_info._exp_yml:
-					if [rev.name for rev in selection.revisions] != ['_none']:
+					if selection.revisions is not None:
 						yield from selection.revisions
 					else:
 						yield from self.all_revisions()
 				else:
-					yield Revision(self, {'name': '_none'})
+					yield None
 
 			for exp_info in selection.experiments:
 				for revision in revisions_for_experiment(exp_info):
@@ -248,7 +248,8 @@ class Config:
 							for rep in reps:
 								yield (Experiment(self, exp_info, revision, variation), instance, rep)
 
-		key = lambda t: (t[0].name, t[0].revision.name, [sub_var.name for sub_var in t[0].variation], t[1].shortname, t[2])
+		key = lambda t: (t[0].name, t[0].revision.name if t[0].revision is not None else '_none',
+						 [sub_var.name for sub_var in t[0].variation], t[1].shortname, t[2])
 		for experiment, instance, rep in self._expand_matrix(extract, key=key):
 			yield Run(self, experiment, instance, rep)
 
@@ -362,7 +363,7 @@ class Config:
 	def _get_selected_revisions(self, scope):
 		if scope.revisions is not None:
 			return [self.get_revision(revision) for revision in scope.revisions]
-		return [Revision(self, {'name': '_none'})]
+		return None
 
 	# Determine all instances selected by a scope.
 	def _get_selected_instances(self, scope):

--- a/simexpal/build.py
+++ b/simexpal/build.py
@@ -96,6 +96,8 @@ def make_build_in_order(cfg, build, wanted_builds, wanted_phases):
 				return build.clone_dir
 			else:
 				return build.source_dir
+		elif var == 'THIS_COMPILE_DIR':
+			return build.compile_dir
 		elif var == 'THIS_PREFIX_DIR':
 			return build.prefix_dir
 		elif var == 'PARALLELISM':

--- a/simexpal/build.py
+++ b/simexpal/build.py
@@ -99,6 +99,10 @@ def make_build_in_order(cfg, build, wanted_builds, wanted_phases):
 		other_build = cfg.get_build(build_name, build.revision)
 		return other_build.compile_dir
 
+	def get_prefix_dir_for(build_name):
+		other_build = cfg.get_build(build_name, build.revision)
+		return other_build.prefix_dir
+
 	def substitute(var):
 		# 'THIS_SOURCE_DIR' is prefered, 'THIS_CLONE_DIR' is deprecated
 		if var in ['THIS_CLONE_DIR', 'THIS_SOURCE_DIR']:
@@ -114,6 +118,8 @@ def make_build_in_order(cfg, build, wanted_builds, wanted_phases):
 			return get_source_dir_for(var.split(':')[1])
 		elif var.startswith('COMPILE_DIR_FOR:'):
 			return get_compile_dir_for(var.split(':')[1])
+		elif var.startswith('PREFIX_DIR_FOR:'):
+			return get_prefix_dir_for(var.split(':')[1])
 		elif var == 'PARALLELISM':
 			return str(get_concurrency())
 

--- a/simexpal/build.py
+++ b/simexpal/build.py
@@ -89,6 +89,12 @@ def make_build_in_order(cfg, build, wanted_builds, wanted_phases):
 			n = os.cpu_count()
 		return n
 
+	def get_source_dir_for(build_name):
+		other_build = cfg.get_build(build_name, build.revision)
+		if not other_build.revision.is_dev_build:
+			return other_build.clone_dir
+		return other_build.source_dir
+
 	def substitute(var):
 		# 'THIS_SOURCE_DIR' is prefered, 'THIS_CLONE_DIR' is deprecated
 		if var in ['THIS_CLONE_DIR', 'THIS_SOURCE_DIR']:
@@ -100,6 +106,8 @@ def make_build_in_order(cfg, build, wanted_builds, wanted_phases):
 			return build.compile_dir
 		elif var == 'THIS_PREFIX_DIR':
 			return build.prefix_dir
+		elif var.startswith('SOURCE_DIR_FOR:'):
+			return get_source_dir_for(var.split(':')[1])
 		elif var == 'PARALLELISM':
 			return str(get_concurrency())
 

--- a/simexpal/build.py
+++ b/simexpal/build.py
@@ -95,6 +95,10 @@ def make_build_in_order(cfg, build, wanted_builds, wanted_phases):
 			return other_build.clone_dir
 		return other_build.source_dir
 
+	def get_compile_dir_for(build_name):
+		other_build = cfg.get_build(build_name, build.revision)
+		return other_build.compile_dir
+
 	def substitute(var):
 		# 'THIS_SOURCE_DIR' is prefered, 'THIS_CLONE_DIR' is deprecated
 		if var in ['THIS_CLONE_DIR', 'THIS_SOURCE_DIR']:
@@ -108,6 +112,8 @@ def make_build_in_order(cfg, build, wanted_builds, wanted_phases):
 			return build.prefix_dir
 		elif var.startswith('SOURCE_DIR_FOR:'):
 			return get_source_dir_for(var.split(':')[1])
+		elif var.startswith('COMPILE_DIR_FOR:'):
+			return get_compile_dir_for(var.split(':')[1])
 		elif var == 'PARALLELISM':
 			return str(get_concurrency())
 

--- a/simexpal/launch/common.py
+++ b/simexpal/launch/common.py
@@ -276,7 +276,7 @@ def invoke_run(manifest):
 	def substitute(p):
 		if p == 'INSTANCE':
 			return manifest.instance_dir + '/' + manifest.instance_yml_name
-		elif p[:9] == 'INSTANCE:':
+		elif p.startswith('INSTANCE:'):
 			return get_qualified_filename(p.split(':')[1])
 		elif p == 'REPETITION':
 			return str(manifest.repetition)


### PR DESCRIPTION
This PR contains the following:

- Added support for `@THIS_COMPILE_DIR@`, `@SOURCE_DIR_FOR:<build_name>@`, `@SOURCE_DIR_FOR:<build_name>@` and `@SOURCE_DIR_FOR:<build_name>@` variable in build args
- minor refactoring of string matching in `substitute()` in `invoke_run()`
- fix for a bug where `'_none'` was displayed as revision in the terminal for experiments that do not have a revision
- remove usage of Revision objects that had `'_none'` as a name by adapting the sorting key that is passed into `Config._expand_matrix()`