### PR TITLE
compact experiments list and full experiment name

### DIFF
--- a/scripts/simex
+++ b/scripts/simex
@@ -286,6 +286,7 @@ dev_builds_parser.add_argument('builds', nargs='+', type=str)
 def do_experiments(args):
 	args.detailed = False
 	args.compact = False
+	args.full = False
 
 	return do_experiments_list(args, as_default_subcmd=True)
 
@@ -305,7 +306,7 @@ def do_experiments_list(args, as_default_subcmd=False):
 			return colors['red']
 		return ''
 
-	def show_compact_list():
+	def show_compact_list(calc_exp_len=False):
 
 		def print_experiment_statistics():
 
@@ -329,14 +330,19 @@ def do_experiments_list(args, as_default_subcmd=False):
 												include_status_string=True)
 
 			for e_entry, s_entry, fin_entry, fail_entry, o_entry in zip_longest(
-				[exp_name], started_statistics, finished_statistics, failures_statistics, other_statistics, fillvalue=''):
+					[exp_name], started_statistics, finished_statistics, failures_statistics, other_statistics, fillvalue=''):
 
-				print('{:30.30} {:10.10} {:10.10} {:20.20} {}'.format(e_entry, s_entry, fin_entry, fail_entry, o_entry))
+				print('{:30.30} {:10.10} {:10.10} {:20.20} {}'.format(e_entry, s_entry, fin_entry, fail_entry, o_entry,	len=exp_len))
 
-		print('{:30.30} {:10.10} {:10.10} {:20.20} {}'.format(
-			'Experiment', 'started', 'finished', 'failures', 'other'))
-		print('{:30.30} {:10.10} {:10.10} {:20.20} {}'.format(
-			'----------', '-------', '--------', '--------', '-----'))
+		if calc_exp_len:
+			exp_len = max([len(run.experiment.name) for run in selection])
+		else:
+			exp_len = 30
+
+		print('{:{len}.{len}} {:10.10} {:10.10} {:20.20} {}'.format(
+			'Experiment', 'started', 'finished', 'failures', 'other', len=exp_len))
+		print('{:{len}.{len}} {:10.10} {:10.10} {:20.20} {}'.format(
+			'----------', '-------', '--------', '--------', '-----', len=exp_len))
 
 		exp_name = None
 		status_dict = {}
@@ -358,40 +364,44 @@ def do_experiments_list(args, as_default_subcmd=False):
 
 		print_experiment_statistics()
 
-	def show_detailed_list():
-		print('{:45.45} {:35.35} {}'.format('Experiment', 'Instance', 'Status'))
-		print('{:45.45} {:35.35} {}'.format('----------', '--------', '------'))
+	def show_detailed_list(calc_exp_len=False):
+		if calc_exp_len:
+			exp_len = max([len(run.experiment.display_name) for run in selection])
+		else:
+			exp_len = 45
+
+		print('{:{len}.{len}} {:35.35} {}'.format('Experiment', 'Instance', 'Status', len=exp_len))
+		print('{:{len}.{len}} {:35.35} {}'.format('----------', '--------', '------', len=exp_len))
 		for run in selection:
 			exp, instance, status = (run.experiment, run.instance.shortname, run.get_status())
 
 			print(color_for_status(status), end='')
-			print('{:45.45} {:35.35} [{}] {}'.format(exp.display_name, instance, run.repetition, str(status)))
+			print('{:{len}.{len}} {:35.35} [{}] {}'.format(exp.display_name, instance, run.repetition, str(status), len=exp_len))
 			print(colors['reset'], end='')
 
 	cfg = extl.base.config_for_dir()
 
 	if as_default_subcmd:
-		selection = cfg.discover_all_runs()
+		selection = list(cfg.discover_all_runs())
 	else:
-		selection = select_runs_from_cli(cfg, args)
+		selection = list(select_runs_from_cli(cfg, args))
 
 	if args.detailed:
-		show_detailed_list()
+		show_detailed_list(args.full)
 	elif args.compact:
-		show_compact_list()
+		show_compact_list(args.full)
 	else:
-		selection = list(selection)
 		if len(selection) < simexpal.base.EXPERIMENTS_LIST_THRESHOLD:
-			show_detailed_list()
+			show_detailed_list(args.full)
 		else:
-			show_compact_list()
-
+			show_compact_list(args.full)
 
 experiments_list_parser = experiments_subcmds.add_parser('list',
 		parents=[run_selection_parser])
 experiments_list_parser.set_defaults(cmd=do_experiments_list)
 experiments_list_parser.add_argument('--compact', action='store_true')
 experiments_list_parser.add_argument('--detailed', action='store_true')
+experiments_list_parser.add_argument('--full', action='store_true')
 
 def do_experiments_launch(args):
 	cfg = extl.base.config_for_dir()

--- a/scripts/simex
+++ b/scripts/simex
@@ -17,6 +17,8 @@ import simexpal.launch.slurm
 import simexpal.launch.sge
 import simexpal.queuesock
 import simexpal.util as util
+from simexpal.base import Status
+from itertools import zip_longest
 import yaml
 
 colors = {
@@ -282,6 +284,9 @@ dev_builds_parser.add_argument('builds', nargs='+', type=str)
 # ---------------------------------------------------------------------------------------
 
 def do_experiments(args):
+	args.detailed = False
+	args.compact = False
+
 	return do_experiments_list(args, as_default_subcmd=True)
 
 experiments_parser = main_subcmds.add_parser('experiments', help='Manage experiments',
@@ -300,6 +305,59 @@ def do_experiments_list(args, as_default_subcmd=False):
 			return colors['red']
 		return ''
 
+	def show_compact_list():
+
+		def print_experiment_statistics():
+
+			def _get_table_entries(status_list, include_status_string=False):
+				entry_list = []
+				for s in status_list:
+					if status_dict[s] > 0:
+						prefix = ''
+						if include_status_string:
+							prefix = str(s) + ': '
+
+						entry_list.append(prefix + str(status_dict[s]) + '/' + str(num_runs))
+
+				return entry_list
+
+			started_statistics = _get_table_entries([Status.STARTED])
+			finished_statistics = _get_table_entries([Status.FINISHED])
+			failures_statistics = _get_table_entries([status for status in Status if status.is_negative],
+													include_status_string=True)
+			other_statistics = _get_table_entries([Status.NOT_SUBMITTED, Status.IN_SUBMISSION, Status.SUBMITTED],
+												include_status_string=True)
+
+			for e_entry, s_entry, fin_entry, fail_entry, o_entry in zip_longest(
+				[exp_name], started_statistics, finished_statistics, failures_statistics, other_statistics, fillvalue=''):
+
+				print('{:30.30} {:10.10} {:10.10} {:20.20} {}'.format(e_entry, s_entry, fin_entry, fail_entry, o_entry))
+
+		print('{:30.30} {:10.10} {:10.10} {:20.20} {}'.format(
+			'Experiment', 'started', 'finished', 'failures', 'other'))
+		print('{:30.30} {:10.10} {:10.10} {:20.20} {}'.format(
+			'----------', '-------', '--------', '--------', '-----'))
+
+		exp_name = None
+		status_dict = {}
+		for run in selection:
+			cur_exp_name, cur_status = (run.experiment.name, run.get_status())
+
+			if cur_exp_name != exp_name:  # this check assumes that the runs are sorted by their experiment names
+				if exp_name is not None:
+					print_experiment_statistics()
+
+				# Reset statistics for new experiment
+				exp_name = cur_exp_name
+				for status in simexpal.base.Status:
+					status_dict[status] = 0
+				num_runs = 0  # number of runs of current experiment
+
+			status_dict[cur_status] += 1
+			num_runs += 1
+
+		print_experiment_statistics()
+
 	def show_detailed_list():
 		print('{:45.45} {:35.35} {}'.format('Experiment', 'Instance', 'Status'))
 		print('{:45.45} {:35.35} {}'.format('----------', '--------', '------'))
@@ -317,12 +375,23 @@ def do_experiments_list(args, as_default_subcmd=False):
 	else:
 		selection = select_runs_from_cli(cfg, args)
 
-	show_detailed_list()
+	if args.detailed:
+		show_detailed_list()
+	elif args.compact:
+		show_compact_list()
+	else:
+		selection = list(selection)
+		if len(selection) < simexpal.base.EXPERIMENTS_LIST_THRESHOLD:
+			show_detailed_list()
+		else:
+			show_compact_list()
 
 
 experiments_list_parser = experiments_subcmds.add_parser('list',
 		parents=[run_selection_parser])
 experiments_list_parser.set_defaults(cmd=do_experiments_list)
+experiments_list_parser.add_argument('--compact', action='store_true')
+experiments_list_parser.add_argument('--detailed', action='store_true')
 
 def do_experiments_launch(args):
 	cfg = extl.base.config_for_dir()

--- a/scripts/simex
+++ b/scripts/simex
@@ -290,6 +290,22 @@ experiments_parser.set_defaults(cmd=do_experiments)
 experiments_subcmds = experiments_parser.add_subparsers(dest='experiments_subcmd')
 
 def do_experiments_list(args, as_default_subcmd=False):
+
+	def show_detailed_list():
+		print('{:45.45} {:35.35} {}'.format('Experiment', 'Instance', 'Status'))
+		print('{:45.45} {:35.35} {}'.format('----------', '--------', '------'))
+		for run in selection:
+			exp, instance, status = (run.experiment, run.instance.shortname, run.get_status())
+
+			if status.is_neutral:
+				print(colors['yellow'], end='')
+			elif status.is_positive:
+				print(colors['green'], end='')
+			elif status.is_negative:
+				print(colors['red'], end='')
+			print('{:45.45} {:35.35} [{}] {}'.format(exp.display_name, instance, run.repetition, str(status)))
+			print(colors['reset'], end='')
+
 	cfg = extl.base.config_for_dir()
 
 	if as_default_subcmd:
@@ -297,19 +313,8 @@ def do_experiments_list(args, as_default_subcmd=False):
 	else:
 		selection = select_runs_from_cli(cfg, args)
 
-	print('{:45.45} {:35.35} {}'.format('Experiment', 'Instance', 'Status'))
-	print('{:45.45} {:35.35} {}'.format('----------', '--------', '------'))
-	for run in selection:
-		exp, instance, status = (run.experiment, run.instance.shortname, run.get_status())
+	show_detailed_list()
 
-		if status.is_neutral:
-			print(colors['yellow'], end='')
-		elif status.is_positive:
-			print(colors['green'], end='')
-		elif status.is_negative:
-			print(colors['red'], end='')
-		print('{:45.45} {:35.35} [{}] {}'.format(exp.display_name, instance, run.repetition, str(status)))
-		print(colors['reset'], end='')
 
 experiments_list_parser = experiments_subcmds.add_parser('list',
 		parents=[run_selection_parser])

--- a/scripts/simex
+++ b/scripts/simex
@@ -318,7 +318,9 @@ def do_experiments_list(args, as_default_subcmd=False):
 						if include_status_string:
 							prefix = str(s) + ': '
 
-						entry_list.append(prefix + str(status_dict[s]) + '/' + str(num_runs))
+						entry_list.append((color_for_status(s),
+											prefix + str(status_dict[s]) + '/' + str(num_runs),
+											colors['reset']))
 
 				return entry_list
 
@@ -330,9 +332,11 @@ def do_experiments_list(args, as_default_subcmd=False):
 												include_status_string=True)
 
 			for e_entry, s_entry, fin_entry, fail_entry, o_entry in zip_longest(
-					[exp_name], started_statistics, finished_statistics, failures_statistics, other_statistics, fillvalue=''):
-
-				print('{:30.30} {:10.10} {:10.10} {:20.20} {}'.format(e_entry, s_entry, fin_entry, fail_entry, o_entry,	len=exp_len))
+					[('', exp_name, '')], started_statistics, finished_statistics, failures_statistics, other_statistics,
+					fillvalue=('', '', '')):
+				
+				print('{}{:{len}{}.{len}} {}{:10.10}{} {}{:10.10}{} {}{:20.20}{} {}{}{}'.format(
+					*e_entry, *s_entry, *fin_entry, *fail_entry, *o_entry, len=exp_len))
 
 		if calc_exp_len:
 			exp_len = max([len(run.experiment.name) for run in selection])

--- a/scripts/simex
+++ b/scripts/simex
@@ -291,18 +291,22 @@ experiments_subcmds = experiments_parser.add_subparsers(dest='experiments_subcmd
 
 def do_experiments_list(args, as_default_subcmd=False):
 
+	def color_for_status(status):
+		if status.is_neutral:
+			return colors['yellow']
+		elif status.is_positive:
+			return colors['green']
+		elif status.is_negative:
+			return colors['red']
+		return ''
+
 	def show_detailed_list():
 		print('{:45.45} {:35.35} {}'.format('Experiment', 'Instance', 'Status'))
 		print('{:45.45} {:35.35} {}'.format('----------', '--------', '------'))
 		for run in selection:
 			exp, instance, status = (run.experiment, run.instance.shortname, run.get_status())
 
-			if status.is_neutral:
-				print(colors['yellow'], end='')
-			elif status.is_positive:
-				print(colors['green'], end='')
-			elif status.is_negative:
-				print(colors['red'], end='')
+			print(color_for_status(status), end='')
 			print('{:45.45} {:35.35} [{}] {}'.format(exp.display_name, instance, run.repetition, str(status)))
 			print(colors['reset'], end='')
 

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -10,6 +10,7 @@ from . import instances
 from . import util
 
 DEFAULT_DEV_BUILD_NAME = '_dev'
+EXPERIMENTS_LIST_THRESHOLD = 30
 
 def get_aux_subdir(base_dir, experiment, variation, revision):
 	var = ''


### PR DESCRIPTION
This PR contains the following:
- refactoring of `do_experiments_list`
- addition of constant `EXPERIMENTS_LIST_THRESHOLD=30`
- implementation of https://github.com/hu-macsy/simexpal/issues/39
- added `--full` as option for `simex experiments list`, which will set the experiment column width to the length of the longest experiment `name`/`display_name` instead of using a fixed value

Calling `simex experiments` will now display a **detailed** list of runs if the total number of runs is 
`< EXPERIMENTS_LIST_THRESHOLD` and a **compact** list otherwise.

Calling `simex experiments list --compact` will display a compact list of all runs and looks like this:
<img width="565" alt="simex_experiments_compact" src="https://user-images.githubusercontent.com/50080918/79255687-fe933880-7e86-11ea-86f4-bd75cd2acc07.png">


Calling `simex experiments list --detailed` will display a detailed list of all runs (how it is displayed currently).