### PR TITLE
Feature/purge builds

### DIFF
--- a/scripts/simex
+++ b/scripts/simex
@@ -116,6 +116,18 @@ def select_builds_from_cli(args, broad):
 
 	return sorted(narrow, key=lambda rev: rev.name), narrow
 
+def purge_builds_from(args, selection):
+	ordered_revisions, sel = select_builds_from_cli(args, selection)
+	for revision in ordered_revisions:
+		for build in sel[revision]:
+			if not args.f:
+				print("This would purge build '{}' of revision '{}'. Use '-f' to confirm this action.".format(
+					build.name, build.revision.name))
+				continue
+			else:
+				print("Purging build '{}' of revision '{}'".format(build.name, build.revision.name))
+				build.purge()
+
 build_selection_parser = argparse.ArgumentParser(add_help=False)
 build_selection_parser.add_argument('--revisions', nargs='*', type=str, default=[])
 build_selection_parser.add_argument('builds', nargs='*', type=str)
@@ -273,6 +285,15 @@ def do_builds_make(args):
 
 builds_make_parser = builds_subcmds.add_parser('make')
 builds_make_parser.set_defaults(cmd=do_builds_make)
+
+def do_builds_purge(args):
+	cfg = extl.base.config_for_dir()
+
+	purge_builds_from(args, cfg.all_non_dev_builds())
+
+builds_purge_parser = builds_subcmds.add_parser('purge', parents=[build_selection_parser])
+builds_purge_parser.set_defaults(cmd=do_builds_purge)
+builds_purge_parser.add_argument('-f', action='store_true', help='Execute purge')
 
 # ---------------------------------------------------------------------------------------
 

--- a/scripts/simex
+++ b/scripts/simex
@@ -116,7 +116,7 @@ def select_builds_from_cli(args, broad):
 
 	return sorted(narrow, key=lambda rev: rev.name), narrow
 
-def purge_builds_from(args, selection):
+def purge_builds_from(args, selection, delete_source=False):
 	ordered_revisions, sel = select_builds_from_cli(args, selection)
 	for revision in ordered_revisions:
 		for build in sel[revision]:
@@ -126,7 +126,7 @@ def purge_builds_from(args, selection):
 				continue
 			else:
 				print("Purging build '{}' of revision '{}'".format(build.name, build.revision.name))
-				build.purge()
+				build.purge(delete_source)
 
 build_selection_parser = argparse.ArgumentParser(add_help=False)
 build_selection_parser.add_argument('--revisions', nargs='*', type=str, default=[])
@@ -304,16 +304,22 @@ def do_develop(args):
 	if not wanted_phases:
 		return
 
-	ordered_revisions, sel = select_builds_from_cli(args, cfg.all_dev_builds())
-	for revision in ordered_revisions:
+	if args.purge:
+		purge_builds_from(args, cfg.all_dev_builds(), args.delete_source)
 
-		simexpal.build.make_builds(cfg, revision,
-				[build.info for build in sel[revision]], [build.name for build in sel[revision]], wanted_phases)
+	else:
+		ordered_revisions, sel = select_builds_from_cli(args, cfg.all_dev_builds())
+		for revision in ordered_revisions:
+
+			simexpal.build.make_builds(cfg, revision,
+					[build.info for build in sel[revision]], [build.name for build in sel[revision]], wanted_phases)
 
 dev_builds_parser = main_subcmds.add_parser('develop', help='Build local programs',
 		aliases=['d'], parents=[phase_selection_parser, build_selection_parser])
 dev_builds_parser.set_defaults(cmd=do_develop)
+dev_builds_parser.add_argument('--purge', action='store_true', help='Purge selected dev-builds')
 dev_builds_parser.add_argument('-f', action='store_true', help='Confirm action')
+dev_builds_parser.add_argument('--delete-source', action='store_true', help='Deletes the source directory when purging')
 
 # ---------------------------------------------------------------------------------------
 

--- a/scripts/simex
+++ b/scripts/simex
@@ -278,12 +278,13 @@ builds_subcmds.required = True
 def do_builds_make(args):
 	cfg = extl.base.config_for_dir()
 
-	for revision in cfg.all_revisions():
-		if not revision.is_dev_build:
-			simexpal.build.make_builds(cfg, revision,
-					[build.info for build in cfg.all_builds_for_revision(revision)], [], [])
+	ordered_revisions, sel = select_builds_from_cli(args, cfg.all_non_dev_builds())
+	for revision in ordered_revisions:
 
-builds_make_parser = builds_subcmds.add_parser('make')
+		simexpal.build.make_builds(cfg, revision,
+				[build.info for build in sel[revision]], [], [])
+
+builds_make_parser = builds_subcmds.add_parser('make', parents=[build_selection_parser])
 builds_make_parser.set_defaults(cmd=do_builds_make)
 
 def do_builds_purge(args):

--- a/scripts/simex
+++ b/scripts/simex
@@ -427,36 +427,17 @@ def do_experiments_purge(args):
 			if args.f:
 				print("Purging experiment '{}', instance '{}' [{}]".format(
 						exp.name, instance, run.repetition))
-				try:
-					os.unlink(run.aux_file_path('lock'))
-				except FileNotFoundError:
-					pass
-				try:
-					os.unlink(run.aux_file_path('run'))
-				except FileNotFoundError:
-					pass
-				try:
-					os.unlink(run.aux_file_path('stderr'))
-				except FileNotFoundError:
-					pass
-				try:
-					os.unlink(run.aux_file_path('run.tmp'))
-				except FileNotFoundError:
-					pass
-				try:
-					os.unlink(run.output_file_path('out'))
-				except FileNotFoundError:
-					pass
-				try:
-					os.unlink(run.output_file_path('status'))
-				except FileNotFoundError:
-					pass
-				try:
-					os.unlink(run.output_file_path('status.tmp'))
-				except FileNotFoundError:
-					pass
+
+				util.try_rmfile(run.aux_file_path('lock'))
+				util.try_rmfile(run.aux_file_path('run'))
+				util.try_rmfile(run.aux_file_path('stderr'))
+				util.try_rmfile(run.aux_file_path('run.tmp'))
+				util.try_rmfile(run.output_file_path('out'))
+				util.try_rmfile(run.output_file_path('status'))
+				util.try_rmfile(run.output_file_path('status.tmp'))
+
 			else:
-				print("This would purge experiment '{}', instance '{}' [{}]".format(
+				print("This would purge experiment '{}', instance '{}' [{}]. Use '-f' to confirm this action.".format(
 						exp.name, instance, run.repetition))
 
 experiments_purge_parser = experiments_subcmds.add_parser('purge',

--- a/scripts/simex
+++ b/scripts/simex
@@ -296,6 +296,21 @@ builds_purge_parser = builds_subcmds.add_parser('purge', parents=[build_selectio
 builds_purge_parser.set_defaults(cmd=do_builds_purge)
 builds_purge_parser.add_argument('-f', action='store_true', help='Execute purge')
 
+def do_builds_remake(args):
+	cfg = extl.base.config_for_dir()
+	args.recheckout = True
+	args.f = True
+
+	wanted_phases = select_phases_from_cli(args)
+	ordered_revisions, sel = select_builds_from_cli(args, cfg.all_non_dev_builds())
+	for revision in ordered_revisions:
+
+		simexpal.build.make_builds(cfg, revision,
+				[build.info for build in sel[revision]], [build.name for build in sel[revision]], wanted_phases)
+
+builds_remake_parser = builds_subcmds.add_parser('remake', parents=[build_selection_parser])
+builds_remake_parser.set_defaults(cmd=do_builds_remake)
+
 # ---------------------------------------------------------------------------------------
 
 def do_develop(args):

--- a/scripts/simex
+++ b/scripts/simex
@@ -97,6 +97,31 @@ run_selection_parser.add_argument('--unfinished', action='store_true')
 
 # ---------------------------------------------------------------------------------------
 
+def cli_selects_build(args, build):
+	if len(args.revisions) > 0 and build.revision.name not in args.revisions:
+		return False
+	if len(args.builds) > 0 and build.name not in args.builds:
+		return False
+
+	return True
+
+def select_builds_from_cli(args, broad):
+	narrow = dict()
+	for build in broad:
+		if cli_selects_build(args, build):
+			if build.revision not in narrow:
+				narrow[build.revision] = [build]
+			else:
+				narrow[build.revision].append(build)
+
+	return sorted(narrow, key=lambda rev: rev.name), narrow
+
+build_selection_parser = argparse.ArgumentParser(add_help=False)
+build_selection_parser.add_argument('--revisions', nargs='*', type=str, default=[])
+build_selection_parser.add_argument('builds', nargs='*', type=str)
+
+# ---------------------------------------------------------------------------------------
+
 def select_phases_from_cli(args):
 
 	def subsequent_phases(start_phase):

--- a/scripts/simex
+++ b/scripts/simex
@@ -279,29 +279,20 @@ builds_make_parser.set_defaults(cmd=do_builds_make)
 def do_develop(args):
 	cfg = extl.base.config_for_dir()
 
-	if args.revision is not None:
-		revision = cfg.get_revision(args.revision)
-	else:
-		revision = cfg.get_revision(simexpal.base.DEFAULT_DEV_BUILD_NAME)
-
-	if not revision.is_dev_build:
-		print("Revision '{}' is not a dev-build.".format(revision.name), file=sys.stderr)
+	wanted_phases = select_phases_from_cli(args)
+	if not wanted_phases:
 		return
-	else:
-		wanted_phases = select_phases_from_cli(args)
 
-		if not wanted_phases:
-			return
+	ordered_revisions, sel = select_builds_from_cli(args, cfg.all_dev_builds())
+	for revision in ordered_revisions:
 
 		simexpal.build.make_builds(cfg, revision,
-				[cfg.get_build(build, revision).info for build in args.builds], args.builds, wanted_phases)
+				[build.info for build in sel[revision]], [build.name for build in sel[revision]], wanted_phases)
 
 dev_builds_parser = main_subcmds.add_parser('develop', help='Build local programs',
-		aliases=['d'], parents=[phase_selection_parser])
+		aliases=['d'], parents=[phase_selection_parser, build_selection_parser])
 dev_builds_parser.set_defaults(cmd=do_develop)
 dev_builds_parser.add_argument('-f', action='store_true', help='Confirm action')
-dev_builds_parser.add_argument('--revision', type=str)
-dev_builds_parser.add_argument('builds', nargs='+', type=str)
 
 # ---------------------------------------------------------------------------------------
 

--- a/scripts/simex
+++ b/scripts/simex
@@ -156,8 +156,6 @@ phase_selection_mechanism.add_argument('--reinstall', action='store_true',
 			help='Reinstall build')
 phase_selection_mechanism.add_argument('--install', action='store_true',
 			help='(Re-)Install build')
-phase_selection_parser.add_argument('-f', action='store_true',
-			help='Confirm (re-)checkout')
 
 # ---------------------------------------------------------------------------------------
 # Basic commands.
@@ -276,6 +274,7 @@ def do_develop(args):
 dev_builds_parser = main_subcmds.add_parser('develop', help='Build local programs',
 		aliases=['d'], parents=[phase_selection_parser])
 dev_builds_parser.set_defaults(cmd=do_develop)
+dev_builds_parser.add_argument('-f', action='store_true', help='Confirm action')
 dev_builds_parser.add_argument('--revision', type=str)
 dev_builds_parser.add_argument('builds', nargs='+', type=str)
 

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -152,6 +152,16 @@ class Config:
 	def all_revisions(self):
 		yield from self._revisions.values()
 
+	def all_non_dev_revisions(self):
+		for revision in self.all_revisions():
+			if not revision.is_dev_build:
+				yield revision
+
+	def all_dev_revisions(self):
+		for revision in self.all_revisions():
+			if revision.is_dev_build:
+				yield revision
+
 	def get_revision(self, name):
 		if name is None: # TODO: Questionable special case.
 			return None
@@ -168,6 +178,16 @@ class Config:
 						continue
 					# TODO: Exclude the build if not all requirements are specified in spec_set.
 					yield Build(self, self.get_build_info(build_yml['name']), revision)
+
+	def all_non_dev_builds(self):
+		for build in self.all_builds():
+			if not build.revision.is_dev_build:
+				yield build
+
+	def all_dev_builds(self):
+		for build in self.all_builds():
+			if build.revision.is_dev_build:
+				yield build
 
 	def all_builds_for_revision(self, revision):
 		for build in self.all_builds():

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -750,6 +750,15 @@ class Build:
 	def is_installed(self):
 		return os.access(os.path.join(self.prefix_dir, 'installed.simexpal'), os.F_OK)
 
+	def purge(self, delete_source=False):
+		if not self.revision.is_dev_build:
+			util.try_rmtree(self.clone_dir)
+		elif delete_source:
+			util.try_rmtree(self.source_dir)
+
+		util.try_rmtree(self.compile_dir)
+		util.try_rmtree(self.prefix_dir)
+
 def extract_process_settings(yml):
 	if 'num_nodes' not in yml:
 		return None


### PR DESCRIPTION
This PR contains the  implementation of `simex builds purge` (deletes the `clone_dir`, `compile_dir` and `prefix_dir` of non-dev builds) and `simex develop --purge` (deletes the `compile_dir` and `prefix_dir` of dev builds, if `--delete_source` is used, it will also delete the `source_dir`) .
Both commands take an arbitrary number of build names as positional argument and an arbitrary number of revision names in the `--revision` argument.

Not specifying any build or revision will select all non-dev builds and dev builds respectively.
Only specifying builds will select all the given builds in all revisions.
Only specifying revisions will select all builds in the given revisions.
Specifying both will select the cross-product.

This PR closes https://github.com/hu-macsy/simexpal/issues/38.