### PR TITLE
Support addition of extra paths to PATH environment variable/fix Issue #41

### DIFF
--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -666,6 +666,10 @@ class BuildInfo:
 	def regenerate(self):
 		return self._build_yml.get('regenerate', [])
 
+	@property
+	def extra_paths(self):
+		return self._build_yml.get('extra_paths', [])
+
 class Revision:
 	def __init__(self, cfg, revision_yml):
 		self._cfg = cfg

--- a/simexpal/schemes/schema.json
+++ b/simexpal/schemes/schema.json
@@ -54,7 +54,8 @@
 					"configure": {"$ref": "#/definitions/build_arguments"},
 					"compile": {"$ref": "#/definitions/build_arguments"},
 					"install": {"$ref": "#/definitions/build_arguments"},
-					"exports_python": {"type": "string"}
+					"exports_python": {"type": "string"},
+					"extra_paths": {"$ref": "#/definitions/str_or_str_list"}
 				},
 				"additionalProperties": false
 			}

--- a/simexpal/util.py
+++ b/simexpal/util.py
@@ -12,7 +12,7 @@ def expand_at_params(s, fn, listfn=None):
 	def subfn(m):
 		result = fn(m.group(1))
 		if result is None:
-			raise RuntimeError("Unexpected @-parameter {}".format(s))
+			raise RuntimeError("Unexpected @-parameter '{}' in {}".format(m.group(1), s))
 		return result
 
 	if isinstance(s, list):


### PR DESCRIPTION
This PR fixes #41. This makes it possible to specify extra paths for experiments using the  `extra_paths` key, e.g.:
<pre>
experiments:
     - name: test
       args: ['my', 'experiment', 'arguments']
       extra_paths: ['/first/path', '/second/path']
<pre/>