### PR TITLE
Resolve issue #32, added Run.open_output_file()

### DIFF
--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -122,10 +122,9 @@ on multiple inputs.
         bubble-sort        499500.0  253437.333333  0.091776
         insertion-sort     241891.0  257609.000000  0.039501
 
-    ``eval.py`` is a simple 20 line script that uses the simexpal Python interface
-    (i.e., the function ``collect_successful_results()``) to gather all
-    results. It uses ``pandas`` to aggregate statistics
-    over all experiments.
+    ``eval.py`` is a simple 25 line script that uses the simexpal Python interface
+    (i.e., the functions ``collect_successful_results()`` and ``open_output_file()``)
+    to gather all results. It uses ``pandas`` to aggregate statistics over all experiments.
 
 Running Experiments
 -------------------
@@ -209,24 +208,14 @@ formats and appropriate libraries.
 The example below (i.e., ``eval.py`` from ``examples/sorting/``)
 demonstrates this concept. It uses the simexpal Python package
 to obtain all output files and meta data about them. In particular,
-it uses the function ``collect_successful_results()`` for this purpose.
+it uses the functions ``collect_successful_results()`` and
+``open_output_file()`` for this purpose.
 A user-supplied parsing function is employed to parse the output files.
 
-.. code-block:: python
-
-    def parse(run, f):
-        output = yaml.load(f, Loader=yaml.Loader)
-        return {
-            'experiment': run.experiment.name,
-            'instance': run.instance.shortname,
-            'comparisons': output['comparisons'],
-            'swaps': output['swaps'],
-            'time': output['time']
-        }
-
-    cfg = simexpal.config_for_dir()
-    df = pandas.DataFrame(cfg.collect_successful_results(parse))
-    print(df.groupby('experiment').agg('mean'))
+.. literalinclude:: ../examples/sorting/eval.py
+   :linenos:
+   :lines: 7-24
+   :language: python
 
 Managing Instances
 ------------------

--- a/examples/sorting/eval.py
+++ b/examples/sorting/eval.py
@@ -15,5 +15,10 @@ def parse(run, f):
 	}
 
 cfg = simexpal.config_for_dir()
-df = pandas.DataFrame(cfg.collect_successful_results(parse))
+results = []
+for successful_run in cfg.collect_successful_results():
+	with successful_run.open_output_file() as f:
+		results.append(parse(successful_run, f))
+
+df = pandas.DataFrame(results)
 print(df.groupby('experiment').agg('mean'))

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -977,6 +977,13 @@ class Run:
 
 		return Status.NOT_SUBMITTED
 
+	def open_output_file(self):
+		try:
+			return open(self.output_file_path('out'))
+		except FileNotFoundError:
+			raise RuntimeError("The experiment '{}' with instance '{}' has not been started yet".format(
+				self.experiment.display_name, self.instance.shortname))
+
 def read_and_validate_setup(basedir='.', setup_file='experiments.yml'):
 	return util.validate_setup_file(os.path.join(basedir, setup_file))
 

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -5,9 +5,12 @@ import itertools
 import os
 import yaml
 import sys
+import warnings
 
 from . import instances
 from . import util
+
+warnings.simplefilter(action='default', category=DeprecationWarning)  # do not ignore DeprecationWarnings
 
 DEFAULT_DEV_BUILD_NAME = '_dev'
 EXPERIMENTS_LIST_THRESHOLD = 30
@@ -318,6 +321,11 @@ class Config:
 				yield run
 
 		if parse_fn:
+			msg = "Calling 'Config.collect_successful_results()' with a parse function is deprecated and will be " \
+					"removed in future versions. Instead, call it without any parameters and it will return a " \
+					"generator of successful simexpal.base.Run objects."
+			warnings.warn(msg, DeprecationWarning)
+
 			res = []
 			for run in successful_runs(verbose=True):
 				with open(run.output_file_path('out'), 'r') as f:
@@ -469,8 +477,6 @@ class Instance:
 
 	@property
 	def filename(self):
-		import warnings
-		warnings.simplefilter(action='default', category=DeprecationWarning)
 		msg = "The 'Instance.filename' attribute is deprecated and will be removed in future versions."
 		warnings.warn(msg, DeprecationWarning)
 


### PR DESCRIPTION
This PR contains the following:
- resolves #32 
- added `open_output_file()` to `Run` class as the new `Config.collect_successful_results()` can return a generator of `Run`-objects. This enables an easier access to the `Run` outputs