### PR TITLE
Resolve issue #57

### DIFF
--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -914,8 +914,8 @@ class Experiment:
 
 class Status(IntEnum):
 	NOT_SUBMITTED = 0
-	SUBMITTED = 1
-	IN_SUBMISSION = 2
+	IN_SUBMISSION = 1
+	SUBMITTED = 2
 	STARTED = 3
 	FINISHED = 4
 	TIMEOUT = 5

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -335,6 +335,43 @@ class Config:
 		else:
 			return successful_runs()
 
+	def export_experiments(self, included_statuses=None):
+		"""
+		Exports experiments based on their status.
+
+		:param included_statuses: List of :class:`simexpal.base.Status` objects which get exported.
+			Alternatively an integer list can be used, where the following translation is used:
+			0 - not submitted,
+			1 - in submission,
+			2 - submitted,
+			3 - started,
+			4 - finished,
+			5 - timeout,
+			6 - killed,
+			7 - failed.
+
+		:return: List of (``exp_name``, ``variation-tuple``, ``inst_shortname``, ``status``)-tuples
+		"""
+		experiment_list = []
+
+		if included_statuses is not None:
+			for run in self.discover_all_runs():
+				status = run.get_status()
+				if status in included_statuses:
+					experiment_list.append((
+						run.experiment.name,
+						tuple(variant.name for variant in run.experiment.variation),
+						run.instance.shortname,
+						str(status)
+					))
+		return experiment_list
+
+	def export_successful_experiments(self):
+		return self.export_experiments([s for s in Status if s.is_positive])
+
+	def export_failed_experiments(self):
+		return self.export_experiments([s for s in Status if s.is_negative])
+
 	# -----------------------------------------------------------------------------------
 	# Matrix expansion.
 	# -----------------------------------------------------------------------------------


### PR DESCRIPTION
This PR resolves issue #57. More precisely I added a function ``Config.export_experiments()`` which takes a list of ``Status``-objects or a list of integers (as statuses are interpreted as integer) as parameter. For each ``run`` that matches a status in the input list, the tuple (``run.experiment.name``, ``tuple of used variants``,``run.instance.shortname``, ``run.get_status()``) is added to the output list.

In this way a user can specify which runs are exported. I also added the convenience functions ``Config.export_successful_experiments()`` and ``Config.export_failed_experiments()``.

E.g. calling ``Config.export_successful_experiments()`` on 
<img width="571" alt="image" src="https://user-images.githubusercontent.com/50080918/90790800-bf7b6500-e308-11ea-8b98-8a278a561804.png">
outputs 

<pre>
[('quick-sort', ('ba-bubble', 'bs32'), 'uniform-n1000-s1', 'finished'), 
('quick-sort', ('ba-bubble', 'bs32'), 'uniform-n1000-s2', 'finished'), 
('quick-sort', ('ba-bubble', 'bs64'), 'uniform-n1000-s1', 'finished'), 
('quick-sort', ('ba-bubble', 'bs64'), 'uniform-n1000-s2', 'finished'), 
('quick-sort', ('ba-insert', 'bs32'), 'uniform-n1000-s1', 'finished'), 
('quick-sort', ('ba-insert', 'bs32'), 'uniform-n1000-s2', 'finished')]
</pre>