### PR TITLE
Add documentation for extra_paths/experiments/variants/matrix key, at-variables and fix issues in Quick Start guide

### DIFF
--- a/docs/at_variables_reference.rst
+++ b/docs/at_variables_reference.rst
@@ -1,0 +1,115 @@
+.. _AtVariables:
+
+@-Variables
+===========
+
+@-variables are placeholder variables that can be used in the ``experiments.yml`` file. They are enclosed
+by at signs, i.e. ``@...@`` and get resolved during runtime.
+
+For example: In order to avoid the duplication of command line arguments of experiments for each instance,
+e.g. ``experiment.py /path/to/instance1``, ``experiment.py /path/to/instance2``, ... we use the
+``@INSTANCE@`` variable that resolves to the respective paths of the instances. Then, we only need to
+specify ``experiments.py @INSTANCE@`` as experiment arguments.
+
+..
+    TODO: Add section Instances for generators and INSTANCE_FILENAME variable
+
+Below, we list all @-variables and where they can be used.
+
+- ``@COMPILE_DIR_FOR:<build_name>@``: :ref:`compilation directory <BuildDirectories>` of ``<build_name>`` in the same revision
+- ``@EXTRA_ARGS@``: extra arguments of all variants of an experiment
+- ``@INSTANCE@``: path of a :ref:`local <LocalInstances>`/:ref:`remote <RemoteInstances>` instance, i.e. ``/instance_directory/<instance_name>``
+- ``@INSTANCE:<ext>@``: path of a :ref:`MultipleExtensions` instance with extension ``<ext>``, i.e. ``/instance_directory/<instance_name>.<ext>``
+- ``@INSTANCE:<idx>@``: path of an :ref:`ArbitraryInputFiles` instance with index ``<idx>`` in the ``files`` key, i.e. ``/instance_directory/files[<idx>]``
+- ``@OUTPUT@``: path to the output file of an experiment
+- ``@OUTPUT:<ext>@``: path to the output file with extension ``<ext>`` of an experiment
+- ``@OUTPUT_SUBDIR@``: output subdirectory of the experiment where the output and status files are stored, i.e. ``/path_to_experiments_yml/output/``
+- ``@PARALLELISM@``: number of available CPUs
+- ``@PREFIX_DIR_FOR:<build_name>@``: :ref:`installation directory <BuildDirectories>` of ``<build_name>`` in the same revision
+- ``@REPETITION@``: repetition number of this experiment
+- ``@SOURCE_DIR_FOR:<build_name>@``: :ref:`source directory <BuildDirectories>` of ``<build_name>`` in the same revision
+- ``@THIS_CLONE_DIR@``: Deprecated for ``@THIS_SOURCE_DIR@``
+- ``@THIS_COMPILE_DIR@``: :ref:`compilation directory <BuildDirectories>` of this build
+- ``@THIS_PREFIX_DIR@``: :ref:`installation directory <BuildDirectories>` of this build
+- ``@THIS_SOURCE_DIR@``: :ref:`source directory <BuildDirectories>` of this build
+
+
+
+Builds
+------
+
+.. _AtVariablesBuildsCompile:
+
+compile
+^^^^^^^
+
+The following @-variables can be used in the ``compile`` key:
+
+- ``@COMPILE_DIR_FOR:<build_name>@``
+- ``@PARALLELISM@``
+- ``@PREFIX_DIR_FOR:<build_name>@``
+- ``@SOURCE_DIR_FOR:<build_name>@``
+- ``@THIS_CLONE_DIR@`` (deprecated for ``@THIS_SOURCE_DIR@``)
+- ``@THIS_COMPILE_DIR@``
+- ``@THIS_PREFIX_DIR@``
+- ``@THIS_SOURCE_DIR@``
+
+
+configure
+^^^^^^^^^
+
+Same as for the :ref:`AtVariablesBuildsCompile` key.
+
+environ
+^^^^^^^
+
+The values of the ``environ`` key will be substituted and the @-variables are the same as for
+the :ref:`AtVariablesBuildsCompile` key.
+
+extra_paths
+^^^^^^^^^^^
+
+Same as for the :ref:`AtVariablesBuildsCompile` key `without` the ``@PARALLELISM@`` variable.
+
+install
+^^^^^^^
+
+Same as for the :ref:`AtVariablesBuildsCompile` key.
+
+regenerate
+^^^^^^^^^^
+
+Same as for the :ref:`AtVariablesBuildsCompile` key.
+
+workdir
+^^^^^^^
+
+Same as for the :ref:`AtVariablesBuildsCompile` key.
+
+
+Experiments
+-----------
+
+.. _AtVariablesExperimentsArgs:
+
+args
+^^^^
+
+The following @-variables can be used in the ``args`` key:
+
+- ``@COMPILE_DIR_FOR:<build_name>@`` (``<build>`` has to be in ``used_builds`` or be required by a build in it)
+- ``@EXTRA_ARGS@``
+- ``@INSTANCE@``
+- ``@INSTANCE:<ext>@``
+- ``@INSTANCE:<idx>@``
+- ``@OUTPUT@``
+- ``@OUTPUT:<ext>@``
+- ``@OUTPUT_SUBDIR@``
+- ``@PREFIX_DIR_FOR:<build_name>@`` (``<build_name>`` has to be in ``used_builds`` or be required by a build in it)
+- ``@REPETITION@``
+- ``@SOURCE_DIR_FOR:<build_name>@`` (``<build_name>`` has to be in ``used_builds`` or be required by a build in it)
+
+workdir
+^^^^^^^
+
+Same as for the :ref:`AtVariablesExperimentsArgs` key `without` the ``@EXTRA_ARGS@`` variable.

--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -3,6 +3,11 @@
 Builds
 ======
 
+You might want to take a look at the following pages before exploring automated builds:
+
+- :ref:`QuickStart`
+- :ref:`AtVariables`
+
 To ensure reproducibility of experiments, it is possible to let simexpal pull programs from a VCS (currently
 only Git is supported) and build them automatically. To achieve this, we need to specify a ``builds`` and
 ``revisions`` stanza in the ``experiments.yml``.

--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -186,6 +186,30 @@ key to the respective dictionaries of the build steps.
 Specifying the working directory for other steps works analogously to specifying the working directory for the
 configuration step (as seen above).
 
+Extra Paths
+-----------
+
+For many UNIX packages it is standard to install the executable in the ``@THIS_PREFIX_DIR@/bin`` directory.
+This is why simexpal only checks those directories by default when looking for an executable. However, this
+assumption might not always be correct, for example, when using a custom build system. To cover those cases,
+we specify the
+
+- ``extra_paths``: list of extra paths, which simexpal should check when running an experiment that uses this build
+
+key.
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to specify extra paths of builds in the experiments.yml file.
+
+   builds:
+     - name: build1
+       ...
+       extra_paths: ['/path/to/executable']
+
+When running an experiment that uses this build, simexpal will prepend the paths given in ``extra_paths`` to
+the ``PATH`` environment variable.
+
 Dependent Builds
 ----------------
 

--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -210,6 +210,8 @@ key.
 When running an experiment that uses this build, simexpal will prepend the paths given in ``extra_paths`` to
 the ``PATH`` environment variable.
 
+.. _DependentBuilds:
+
 Dependent Builds
 ----------------
 

--- a/docs/experiments.rst
+++ b/docs/experiments.rst
@@ -1,0 +1,348 @@
+.. _Experiments:
+
+Experiments
+===========
+
+On this page we describe how to specify experiments in our ``experiments.yml`` file. We will see how
+to use builds in experiments, redirect the output and enable options such as repeating experiments or
+setting a timeout. Moreover, we will see that simexpal can be used together with batch schedulers (e.g.
+`Slurm <https://slurm.schedmd.com/overview.html>`_,
+`Oracle Grid Engine <https://docs.oracle.com/cd/E19680-01/html/821-1541/docinfo.html#scrolltoc>`_ (formerly SGE),
+...), and how to set environment variables.
+
+Specifying Experiments
+----------------------
+
+In this section we will see how to specify experiments with different kinds of :ref:`Instances` and
+:ref:`Variants` by using the keys:
+
+- ``name``: name of the experiment
+- ``args``: list of experiment arguments.
+
+.. _ExperimentsWithLocalRemoteInstances:
+
+Experiments with Local/Remote Instances
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Assuming we have a ``./sort.py`` file in the same directory as the ``experiments.yml`` that
+takes a keyword argument ``--algo`` and a path to a single
+(:ref:`local <LocalInstances>`/:ref:`remote <RemoteInstances>`) instance as input, we can define
+our ``experiments.yml`` as follows:
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to specify experiments for local and remote instances in the experiments.yml file.
+
+   experiments:
+     - name: insertion-sort
+       args: ['./sort.py', '--algo=insertion-sort', '@INSTANCE@']
+       output: stdout
+
+In the examples above we created an experiment named `insertion-sort`. As experiment arguments we have
+a list of strings (instead of one space separated string). Note that the :ref:`@-variable <AtVariables>`
+``@INSTANCE@`` resolves to the paths of the instances given in the ``instances`` stanza, i.e,
+``/instance_directory/<instance_name>``.
+
+.. _ExperimentsWithMultipleExtensionInstances:
+
+Experiments with Multiple Extension Instances
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Specifying experiments with :ref:`multiple extension <MultipleExtensions>` instances works similarly to
+specifying experiments with :ref:`local/remote intances <ExperimentsWithLocalRemoteInstances>`. They
+only differ in the used :ref:`@-variable <AtVariables>` in the experiment arguments. Here, we use the
+@-variable ``@INSTANCE:<ext>@``, where ``<ext>`` is an extension that is specified in the
+``extensions`` key of an instance in the ``instances`` stanza.
+
+Assuming you have an algorithm that takes a path to a ``.graph`` and a ``.yxz`` file as input, you can
+specify your experiment as follows:
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to specify experiments for multiple extension instances in the experiments.yml file.
+
+   experiments:
+     - name: graph-algorithm
+       args: ['./algorithm.py', '@INSTANCE:graph', '@INSTANCE:xyz@']
+       output: stdout
+
+The ``@INSTANCE:graph@`` variable will resolve to ``/instance_directory/<instance_name>.graph`` during
+runtime. Analogously for the ``@INSTANCE:xyz@`` variable.
+
+Experiments with Arbitrary Input File Instances
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Specifying experiments with :ref:`arbitrary input file <ArbitraryInputFiles>` instances works similarly to
+specifying experiments with :ref:`multiple extension intances <ExperimentsWithMultipleExtensionInstances>`.
+They only differ in the used :ref:`@-variable <AtVariables>` in the experiment arguments. Here, we use the
+@-variable ``@INSTANCE:<index>@``, where ``<index>`` is the index of the desired file specified in the
+``files`` key of an instance in the ``instances`` stanza. Note that indices start at ``0``.
+
+Assuming you have an algorithm that takes two input files as input and you want to pass the path to the first
+file of the ``files`` key and then the path to the second file to your algorithm, you can specify your experiment
+as follows:
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to specify experiments for arbitrary input file instances in the experiments.yml file.
+
+   experiments:
+     - name: algorithm
+       args: ['./algorithm.py', '@INSTANCE:0', '@INSTANCE:1@']
+       output: stdout
+
+The ``@INSTANCE:0@`` variable will resolve to ``/instance_directory/files[0]``, where ``files[0]`` is
+the first filename of the ``files`` key. Analogously for the ``@INSTANCE:1`` variable.
+
+Experiments with Variants
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To specify experiments with :ref:`Variants` we need to add the ``@EXTRA_ARGS@`` variable to the experiment
+arguments:
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to specify experiments with variants in the experiments.yml file.
+
+   experiments:
+     - name: algorithm
+       args: ['./algorithm.py', '@INSTANCE@', '@EXTRA_ARGS@']
+       output: stdout
+
+The ``@EXTRA_ARGS@`` variable resolves to the extra arguments of all variants of the experiment during runtime.
+For example, assume we have the following ``variants`` stanza:
+
+.. code-block:: YAML
+   :linenos:
+
+   variants:
+     - axis: 'block-algo'
+       items:
+         - name: 'ba-insert'
+           extra_args: ['insertion_sort']
+         - name: 'ba-bubble'
+           extra_args: ['bubble_sort']
+     - axis: 'block-size'
+       items:
+         - name: 'bs32'
+           extra_args: ['32']
+         - name: 'bs64'
+           extra_args: ['64']
+
+Then ``@EXTRA_ARGS@`` will resolve to
+
+- ``'ba-bubble', 'bs32'``,
+- ``'ba-bubble', 'bs64'``,
+- ``'ba-insert', 'bs32'`` and
+- ``'ba-insert', 'bs64'``
+
+in the respective experiments.
+
+Use Builds
+----------
+
+On the :ref:`Builds` page we explained how to set up automated builds. In order to use those builds
+for our experiments we need to specify them with the
+
+- ``use_builds``: list of used build names
+
+key. Assuming that we have defined ``build1`` in our ``builds`` stanza, we can link the build to
+the experiment as follows:
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to specify used builds for experiments in the experiments.yml file.
+
+   experiments:
+     - name: experiment1
+       args: ['<name_of_executable_of_build1>', ...]
+       used_builds: [build1]
+       ...
+
+In this way simexpal will check the :ref:`installation directory <BuildDirectories>` and the ``extra_paths``
+of the builds specified in ``used_builds`` for the executable. If a build
+:ref:`requires other builds <DependentBuilds>` and they are properly specified in the ``requires`` key, then
+simexpal will also check the installation directories and ``extra_paths`` of those builds.
+
+Output
+------
+
+To redirect the output of an experiment to the ``./output/`` folder, we specify the
+
+- ``stdout``: extension of the output file
+- ``output``: dictionary containing all output file extensions
+
+keys.
+
+Assume the following ``experiments`` stanza in our ``experiments.yml``:
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to specify the output file extensions for experiments in the experiments.yml file.
+
+   experiments:
+     - name: experiment1
+       ...
+       stdout: 'out'
+       output:
+         extensions: ['out', 'foo']
+
+Simexpal will then store the outputs in ``<instance_name>.out`` files, which are located in the
+
+- ``./output/<experiment_name>~<variant_names>@<revision_name>``
+
+directory.
+
+.. note::
+   In previous versions of simexpal we would specify the ``output`` key with ``'stdout'`` as value, i.e
+   ``output: 'stdout'``, to achieve the behaviour above. This is deprecated and might be removed in
+   future versions.
+
+The substring ``~<variant_names>`` only appears, if the experiment has variants. ``<variant_names>``
+will then be a comma separated enumeration of the used variants. The suffix ``@<revision_name>``
+appears if the experiment uses builds and shows the name of the used revision.
+
+To access the output files with other extensions, we can use the :ref:`@-variable <AtVariables>`
+``@OUTPUT:<ext>@``, where ``<ext>`` is an extension specified in the ``extensions`` key. This
+@-variable can be used in the ``args`` key of experiments and is useful for use cases like the following:
+
+The experiments that we are running store all intermediate steps and results. Thus, when taking a look at
+the output files, we could encounter thousands (or even more) lines of information even though we might
+only be interested in the last couple of lines. To avoid this, we add another input parameter, which takes a
+file path, to our experiments. We then store the final experiment results in this file. Our experiment ``args``
+could then look like this:
+
+- ``args: ['experiments.py', '@INSTANCE@', '@OUTPUT:foo@']``,
+
+where the first file path is the path to the instance and the second file path is the path to the output file
+that contains the final results (``@OUTPUT:foo@`` will resolve to the output file with extension ``.foo``).
+
+.. _ExperimentsRepeat:
+
+Repeat
+------
+
+Sometimes it might be useful to validate experiment results by repeating the experiment. In order to
+avoid duplicating an ``experiments`` entry we can use the
+
+- ``repeat``: integer - number of times an experiment is repeated
+
+key. To repeat an experiment twice we define our ``experiments`` stanza as follows:
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to specify repetitions for experiments in the experiments.yml file.
+
+   experiments:
+     - name: experiment1
+       ...
+       repeat: 2
+
+The default value of ``repeat`` is ``1``.
+
+Timeout
+-------
+
+It is possible to set a timer for experiments. Once the timer expires, simexpal will terminate the
+experiment. In order to do so we use the
+
+- ``timeout``: integer - timeout in seconds
+
+key. For example we can set the timer for an experiment to two hours as follows:
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to specify a timeout for experiments in the experiments.yml file.
+
+   experiments:
+     - name: experiment1
+       ...
+       timeout: 7200
+
+.. _ExperimentsSettingEnvironmentVariables:
+
+Setting Environment Variables
+-----------------------------
+
+When using APIs like `OpenMP <https://www.openmp.org/spec-html/5.0/openmp.html>`_ it is sometimes
+necessary to specify settings as environment variables. Thus, simexpal supports setting environment
+variables in experiments by specifying the
+
+- ``environ``: dictionary of (environment variable, value)-pairs
+
+key. For example you can specify the ``OMP_NUM_THREADS`` environment variable as follows:
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to specify environment variables for experiments in the experiments.yml file.
+
+   experiments:
+     - name: experiment1
+       args: ...
+       ...
+       environ:
+         OMP_NUM_THREADS: 2
+      - name: experiment2
+        args: ...
+        ...
+        environ:
+         OMP_NUM_THREADS: 4
+
+Slurm
+-----
+
+.. _ExperimentsSupportedSlurmArgs:
+
+sbatch: ``--ntasks-per-node``, ``-c``, ``-N``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When using a job scheduler like `Slurm <https://slurm.schedmd.com/overview.html>`_ it might be
+useful to run your software using different node/cpu settings.
+
+Currently, simexpal supports the following three ``sbatch`` parameters by using its own keywords in
+the ``experiments.yml``:
+
+- ``procs_per_node``: number of tasks to invoke on each node (slurm: ``--ntasks-per-node=n``)
+- ``num_threads``: number of cpus required per task (slurm: ``-c``, ``--cpus-per-task=ncpus``)
+- ``num_nodes``: number of nodes on which to run (N = min[-max]) (slurm: ``-N``, ``--nodes=N``)
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to specify supported Slurm parameters for experiments in the experiments.yml file.
+
+   experiments:
+     - name: experiment1
+       ...
+       num_nodes: 1
+       procs_per_node: 24
+       num_threads: 2
+     - name: experiment2
+       ...
+       num_nodes: 2
+       procs_per_node: 24
+       num_threads: 2
+
+
+When launching your experiments with slurm, the line ``-N 1 --ntasks-per-node 24 -c 2``
+will be appended to the sbatch command for ``experiment1``. Analogously for ``experiment2``.
+
+Arbitrary ``sbatch`` Arguments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In the section before, we saw how to set the values of three supported ``sbatch`` arguments. In
+this section, we will see how to set the value of any supported ``sbatch`` command. To do so, we
+use the
+
+- ``slurm_args``: list of additional ``sbatch`` arguments
+
+key. For example, we can set the job name of an experiment by using the ``-J`` parameter of the
+``sbatch`` command:
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to specify additional Slurm parameters for experiments in the experiments.yml file.
+
+   experiments:
+     - name: experiment1
+       ...
+       slurm_args: ['-J', 'arbitrary_jobname']

--- a/docs/experiments.rst
+++ b/docs/experiments.rst
@@ -3,6 +3,15 @@
 Experiments
 ===========
 
+You might want to take a look at the following pages before exploring experiments:
+
+- :ref:`QuickStart`
+- :ref:`AtVariables`
+- :ref:`Instances`
+- :ref:`Builds`
+- :ref:`Revisions`
+- :ref:`Variants`
+
 On this page we describe how to specify experiments in our ``experiments.yml`` file. We will see how
 to use builds in experiments, redirect the output and enable options such as repeating experiments or
 setting a timeout. Moreover, we will see that simexpal can be used together with batch schedulers (e.g.
@@ -346,3 +355,10 @@ key. For example, we can set the job name of an experiment by using the ``-J`` p
      - name: experiment1
        ...
        slurm_args: ['-J', 'arbitrary_jobname']
+
+Next
+----
+
+To get a more detailed understanding of experiment variants and fully set up your experiments, you
+can visit the :ref:`Variants` page. If you do not plan on having experiments, you can visit the
+:ref:`RunMatrix` page to modify the experiment combinations that you want to run.

--- a/docs/experiments_reference.rst
+++ b/docs/experiments_reference.rst
@@ -80,3 +80,19 @@ Each experiment includes three keys:
 - ``use_builds``: list of used build names
 
 For detailed usage examples, see the :ref:`Experiments` page.
+
+Variants
+--------
+This entry is a list of variants that will be used for experiments. The following keys are
+used for specifying variants:
+
+- ``axis``: name of the variant axis
+- ``environ``: dictionary of (environment variable, value)-pairs
+- ``extra_args``: list of variant arguments
+- ``items``: list of dictionaries, which specify variants belonging to the same axis.
+- ``name``: name of the variant
+- ``num_nodes``: number of nodes on which to run
+- ``num_threads``: number of cpus required per task
+- ``procs_per_node``: number of tasks to invoke on each node
+
+For detailed usage examples, see the :ref:`Variants` page.

--- a/docs/experiments_reference.rst
+++ b/docs/experiments_reference.rst
@@ -1,21 +1,21 @@
 The "experiments.yml" reference
 ===============================
 
-Simexpal needs an "experiments.yml" file to to automatically execute your experiments
-on the desired instances. In this page we describe the structure of the "experiments.yml"
-file. The "experiments.yml" is a YAML file that contains a dictionary with several keys:
+Simexpal needs an ``experiments.yml`` file to to automatically execute your experiments
+on the desired instances. In this page we describe the structure of the ``experiments.yml``
+file. The ``experiments.yml`` is a YAML file that contains a dictionary with several keys:
 
-- instances: list of all the instances that will be used for the experiments.
-- instdir: path to the directory that stores all the instances.
-- experiments: list of all the experiments that will be executed on the instances.
+- ``instances``: list of all the instances that will be used for the experiments
+- ``instdir``: path to the directory that stores all the instances
+- ``experiments``: list of all the experiments that will be executed on the instances
 
 There are also further keys that allow for customization of the experiments and to
 automatically build the binaries the experiments run from:
 
-- builds: list of Git builds, which also include build instructions.
-- revisions: list of Git revisions of builds.
-- variants: list of additional input parameters for experiments.
-- matrix: specifies which combinations of experiments, instances, variants and revisions are run.
+- ``builds``: list of Git builds, which also include build instructions
+- ``revisions``: list of Git revisions of builds
+- ``variants``: list of additional input parameters for experiments
+- ``matrix``: specifies which combinations of experiments, instances, variants and revisions are run
 
 Instances
 ---------

--- a/docs/experiments_reference.rst
+++ b/docs/experiments_reference.rst
@@ -65,18 +65,18 @@ Experiments
 This entry is a list of experiments that will be executed on all the instances.
 Each experiment includes three keys:
 
-- name: a unique identifier of the experiment.
-- args: list of command-line arguments to run the code of the experiment.
-- output: where the result of the experiments should be saved.
 
-In the example below we show how to run two experiments (insertion-sort and bubble-sort)
-on our instances.
-demo.py is the code that executes our experiment and accepts two arguments:
-the sorting algorithm and the path of the instance.
-The resulting data will be outputted to the standard output.
+- ``args``: list of experiment arguments
+- ``environ``: dictionary of (environment variable, value)-pairs
+- ``name``: name of the experiment
+- ``num_nodes``: number of nodes on which to run
+- ``num_threads``: number of cpus required per task
+- ``output``: dictionary containing all output file extensions
+- ``procs_per_node``: number of tasks to invoke on each node
+- ``repeat``: integer - number of times an experiment is repeated
+- ``slurm_args``: list of additional ``sbatch`` arguments
+- ``stdout``: extension of the output file
+- ``timeout``: integer - timeout in seconds
+- ``use_builds``: list of used build names
 
-.. literalinclude:: ./experiments.yml.example
-   :linenos:
-   :lines: 8-
-   :language: yaml
-   :caption: How to list experiments in the experiments.yml file.
+For detailed usage examples, see the :ref:`Experiments` page.

--- a/docs/experiments_reference.rst
+++ b/docs/experiments_reference.rst
@@ -96,3 +96,18 @@ used for specifying variants:
 - ``procs_per_node``: number of tasks to invoke on each node
 
 For detailed usage examples, see the :ref:`Variants` page.
+
+Run Matrix
+----------
+This entry is a list of desired experiment combinations. The following keys are
+used for specifying desired experiment combinations:
+
+- ``axes``: list of included axis names
+- ``experiments``: list of included experiment names
+- ``include``: list of dictionaries, which specify included experiment combinations
+- ``instsets``: list of included instance set names
+- ``repetitions``: integer - number of times all combinations of an ``include`` entry are repeated
+- ``revisions``: list of included revision names
+- ``variants``: list of included variant names
+
+For detailed usage examples, see the :ref:`RunMatrix` page.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Welcome to simexpal's documentation!
    Revisions <revisions>
    Experiments <experiments>
    Variants <variants>
+   Run Matrix <run_matrix>
    Command-line Reference <command_line_reference>
    Python API <python_api>
    Recipes <recipes>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Welcome to simexpal's documentation!
 
    Quick Start <quick_start>
    Reference for experiments.yml file <experiments_reference>
+   Reference for @-variables <at_variables_reference>
    Instances <instances>
    Builds <builds>
    Revisions <revisions>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,7 @@ Welcome to simexpal's documentation!
    Instances <instances>
    Builds <builds>
    Revisions <revisions>
+   Experiments <experiments>
    Command-line Reference <command_line_reference>
    Python API <python_api>
    Recipes <recipes>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Welcome to simexpal's documentation!
    Builds <builds>
    Revisions <revisions>
    Experiments <experiments>
+   Variants <variants>
    Command-line Reference <command_line_reference>
    Python API <python_api>
    Recipes <recipes>

--- a/docs/instances.rst
+++ b/docs/instances.rst
@@ -47,6 +47,8 @@ An example of how to list a local set of instances is:
 ..
     TODO: Add section on instance generators
 
+.. _RemoteInstances:
+
 Remote Instances
 ----------------
 
@@ -91,6 +93,8 @@ Below we distinguish two cases:
 1. The input filenames only differ in the extension, e.g. ``foo.graph`` and ``foo.xyz``.
 2. The input filenames are arbitrary.
 
+.. _MultipleExtensions:
+
 Multiple Extensions
 ^^^^^^^^^^^^^^^^^^^
 
@@ -116,6 +120,8 @@ difference is that we will add the following key:
 The ``experiments.yml`` file above will create the instance ``foo`` which contains the files
 ``foo.graph`` and ``foo.xyz`` and the instance ``bar`` which contains the files
 ``bar.graph`` and ``bar.xyz``.
+
+.. _ArbitraryInputFiles:
 
 Arbitrary Input Files
 ^^^^^^^^^^^^^^^^^^^^^
@@ -180,4 +186,4 @@ In this way we have created the instance set ``set1``, which contains ``instance
 and ``set2``, which contains ``instance2`` and ``instance3``.
 
 Instance sets will also be useful when using the :ref:`command line interface <CommandLineReference>` of
-simexpal and when defining the run matrix.
+simexpal and when defining the :ref:`RunMatrix`.

--- a/docs/instances.rst
+++ b/docs/instances.rst
@@ -3,6 +3,10 @@
 Instances
 =========
 
+You might want to take a look at the following pages before exploring instances:
+
+- :ref:`QuickStart`
+
 On this page we describe how to specify instances in the ``experiments.yml`` file. You can
 list local instances that consist of one file or several files. More over simexpal can download
 remote instances from the `KONECT <http://konect.cc>`_ and `SNAP <https://snap.stanford.edu/data/>`_
@@ -189,3 +193,9 @@ and ``set2``, which contains ``instance2`` and ``instance3``.
 
 Instance sets will also be useful when using the :ref:`command line interface <CommandLineReference>` of
 simexpal and when defining the :ref:`RunMatrix`.
+
+Next
+----
+
+To set up your automated builds, visit the :ref:`Builds` page. If you do not plan on using
+automated builds, you can visit the :ref:`Experiments` page to set up your experiments.

--- a/docs/instances.rst
+++ b/docs/instances.rst
@@ -153,6 +153,8 @@ The ``experiments.yml`` file above will create the instance ``foo`` which contai
 ``file1`` and ``file2`` and the instance ``bar`` which contains the files
 ``file3`` and ``file4``.
 
+.. _InstanceSets:
+
 Instance Sets
 -------------
 

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -336,15 +336,18 @@ stanzas to ``experiments.yml``. In our example, these look like:
                                                                       # of a branch by specifying the SHA-1 hash or
                                                                       # branch name (not recommended for reproducibility reasons)
 
-Next, we have to assign the builds to their respective experiments
+Next, we have to assign the builds to their respective experiments:
 
 .. code-block:: YAML
 
     experiments:
       - name: quick-sort
         use_builds: [simexpal]  # specify which builds get used for this experiment
-        args: ['quicksort', '@INSTANCE@']
+        args: ['quicksort', '@INSTANCE@', '@EXTRA_ARGS@']
         output: stdout
+
+Simexpal resolves the ``@INSTANCE@`` variable to the instance paths and the ``@EXTRA_ARGS@``
+to the extra arguments of the variants (that we define below) during runtime.
 
 After ``experiments.yml`` has been adopted, we can run the automated build
 using
@@ -407,14 +410,14 @@ Using ``simex experiments list`` we can confirm that we got our desired experime
 
 .. code-block:: bash
 
-    Experiment                                    Instance                            Status
-    ----------                                    --------                            ------
-    quick-sort ~ ba-bubble, bs32 @ main           uniform-n1000-s1                    [0] not submitted
-    quick-sort ~ ba-bubble, bs32 @ main           uniform-n1000-s2                    [0] not submitted
-    quick-sort ~ ba-bubble, bs64 @ main           uniform-n1000-s1                    [0] not submitted
-    quick-sort ~ ba-bubble, bs64 @ main           uniform-n1000-s2                    [0] not submitted
-    quick-sort ~ ba-insert, bs32 @ main           uniform-n1000-s1                    [0] not submitted
-    quick-sort ~ ba-insert, bs32 @ main           uniform-n1000-s2                    [0] not submitted
+    Experiment                                    Instance                     Status
+    ----------                                    --------                     ------
+    quick-sort ~ ba-bubble, bs32 @ main           uniform-n1000-s1             [0] not submitted
+    quick-sort ~ ba-bubble, bs32 @ main           uniform-n1000-s2             [0] not submitted
+    quick-sort ~ ba-bubble, bs64 @ main           uniform-n1000-s1             [0] not submitted
+    quick-sort ~ ba-bubble, bs64 @ main           uniform-n1000-s2             [0] not submitted
+    quick-sort ~ ba-insert, bs32 @ main           uniform-n1000-s1             [0] not submitted
+    quick-sort ~ ba-insert, bs32 @ main           uniform-n1000-s2             [0] not submitted
 
 Launchers / Support for Batch Schedulers
 ----------------------------------------

--- a/docs/revisions.rst
+++ b/docs/revisions.rst
@@ -3,7 +3,11 @@
 Revisions
 =========
 
-(Make sure you checked out the page regarding :ref:`Builds` before reading this page.)
+You might want to take a look at the following pages before exploring revisions:
+
+- :ref:`QuickStart`
+- :ref:`AtVariables`
+- :ref:`Builds`
 
 Simexpal supports two kinds of revisions: "normal" (static) revisions and develop (dynamic) revisions. If you have
 a finished project and only want to run experiments, normal revisions will suffice. If your project is not finished
@@ -72,3 +76,9 @@ latest project files.
 
 .. note::
    It is possible to have normal and develop revisions at the same time.
+
+Next
+----
+
+Now that you have set up your automated builds, you can visit the :ref:`Experiments` page to define
+your experiments.

--- a/docs/run_matrix.rst
+++ b/docs/run_matrix.rst
@@ -3,6 +3,16 @@
 Run Matrix
 ==========
 
+You might want to take a look at the following pages before exploring the run matrix:
+
+- :ref:`QuickStart`
+- :ref:`AtVariables`
+- :ref:`Instances`
+- :ref:`Builds`
+- :ref:`Revisions`
+- :ref:`Experiments`
+- :ref:`Variants`
+
 Simexpal will build every possible combination of :ref:`experiment <Experiments>`,
 :ref:`instance <Instances>`, :ref:`variant <Variants>` and :ref:`revision <Revisions>`.
 There are cases where this is not desired. For example, you might only want to run certain

--- a/docs/run_matrix.rst
+++ b/docs/run_matrix.rst
@@ -1,0 +1,155 @@
+.. _RunMatrix:
+
+Run Matrix
+==========
+
+Simexpal will build every possible combination of :ref:`experiment <Experiments>`,
+:ref:`instance <Instances>`, :ref:`variant <Variants>` and :ref:`revision <Revisions>`.
+There are cases where this is not desired. For example, you might only want to run certain
+instance/variant combinations. On this page we describe how to use the ``matrix`` key in the
+``experiments.yml`` file and will mainly use the
+`C++ example <https://github.com/hu-macsy/simexpal/tree/master/examples/sorting_cpp>`_ from
+the :ref:`QuickStart` guide in order to do so.
+
+Include Experiments
+-------------------
+
+Currently the ``matrix`` key works by specifying all the experiment combinations that you want
+to include. Therefore, we will specify the
+
+- ``include``: list of dictionaries, which specify included experiment combinations
+
+key.
+
+Each entry of ``include`` can contain the following keys:
+
+- ``experiments``: list of included experiment names
+- ``instsets``: list of included instance set names
+- ``axes``: list of included axis names
+- ``variants``: list of included variant names
+- ``revisions``: list of included revision names
+
+Simexpal will then build the cross product of each experiment, instance set, variant and revision
+for each entry in ``include``. Omitting a key in ``include`` will select all possible elements of
+the respective key, e.g., omitting ``revisions`` is equivalent to specifying the ``revisions`` key
+with all possible revisions.
+
+The ``matrix`` key of
+
+.. code-block:: YAML
+    :linenos:
+
+    matrix:
+      include:
+        - experiments: [quick-sort]
+          variants: [ba-insert, bs32]
+          revisions: [main]
+        - experiments: [quick-sort]
+          variants: [ba-bubble]
+          revisions: [main]
+
+(The full ``experiments.yml`` can be found `here <https://github.com/hu-macsy/simexpal/tree/master/examples/sorting_cpp>`_ .)
+
+results in the following experiments (using ``simex experiments list`` to display them):
+
+.. code-block:: bash
+
+    Experiment                                    Instance                     Status
+    ----------                                    --------                     ------
+    quick-sort ~ ba-bubble, bs32 @ main           uniform-n1000-s1             [0] not submitted
+    quick-sort ~ ba-bubble, bs32 @ main           uniform-n1000-s2             [0] not submitted
+    quick-sort ~ ba-bubble, bs64 @ main           uniform-n1000-s1             [0] not submitted
+    quick-sort ~ ba-bubble, bs64 @ main           uniform-n1000-s2             [0] not submitted
+    quick-sort ~ ba-insert, bs32 @ main           uniform-n1000-s1             [0] not submitted
+    quick-sort ~ ba-insert, bs32 @ main           uniform-n1000-s2             [0] not submitted
+
+.. note::
+    If the ``axes`` key is omitted and the ``variants`` key does not contain any variant of an axis, then
+    every variant of this axis will be selected. If this is not intended you need to specify the ``axes``
+    key with the names of the desired axes.
+
+If we wanted the second entry of the ``include`` key in the ``experiments.yml`` above, to only include
+the variant ``ba-bubble`` (without any other variants of other axes), we would need to specify the
+``axes`` key like this:
+
+.. code-block:: YAML
+    :linenos:
+
+    matrix:
+      include:
+        - experiments: [quick-sort]
+          variants: [ba-insert, bs32]
+          revisions: [main]
+        - experiments: [quick-sort]
+          axes: [block-algo]
+          variants: [ba-bubble]
+          revisions: [main]
+
+In this way  we obtain the experiments:
+
+.. code-block:: bash
+
+    Experiment                                    Instance                     Status
+    ----------                                    --------                     ------
+    quick-sort ~ ba-bubble @ main                 uniform-n1000-s1             [0] not submitted
+    quick-sort ~ ba-bubble @ main                 uniform-n1000-s2             [0] not submitted
+    quick-sort ~ ba-insert, bs32 @ main           uniform-n1000-s1             [0] not submitted
+    quick-sort ~ ba-insert, bs32 @ main           uniform-n1000-s2             [0] not submitted
+
+Repetitions
+-----------
+
+.. note::
+   Repetitions specified in the run matrix will override the values of ``repeat`` specified in the
+   ``experiments`` stanza.
+
+Similarly to :ref:`repeating experiments <ExperimentsRepeat>` we can repeat all experiment combinations
+of an ``include`` entry by specifying
+
+- ``repetitions``: integer - number of times all combinations of an ``include`` entry are repeated.
+
+To repeat experiments twice, we can define the key as follows:
+
+.. code-block:: YAML
+    :linenos:
+    :caption: How to specify repetitions in the matrix key of an experiments.yml file.
+
+    matrix:
+      include:
+        - experiments: [...]
+          variants: [...]
+          ...
+          repetitions: 2
+
+The default value of ``repetitions`` is ``1``.
+
+More Examples
+-------------
+
+Experiments with Different Instance Types
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When you are dealing with experiments that have different instance types, e.g. :ref:`MultipleExtensions`
+Instances and :ref:`LocalInstances`, you need to use :ref:`InstanceSets` and the ``instsets`` key
+appropriately. This means:
+
+First, you have to assign your instances with different types to separate instance sets. For example, you
+can assign your multiple extension instances to the instance set ``multiple_extension_set`` and your local
+instances to ``local_instance_set``. Assuming you have defined two experiments ``multiple_ext_experiment``
+and ``local_experiment`` that take multiple extension and local instances as input respectively, you can
+specify your run matrix as follows:
+
+.. code-block:: YAML
+    :linenos:
+    :caption: How to specify experiments with different instance types in the run matrix of the experiments.yml file.
+
+    matrix:
+      include:
+        - experiments: [multiple_ext_experiment]
+          instsets: [multiple_extension_set]
+          ...
+        - experiments: [local_experiment]
+          instsets: [local_instance_set]
+          ...
+
+In this way, we can assure that the right instance paths are passed to each experiment.

--- a/docs/variants.rst
+++ b/docs/variants.rst
@@ -1,0 +1,130 @@
+.. _Variants:
+
+Variants
+========
+
+When benchmarking algorithms, it is often useful to compare different variants or parameter
+configurations of the same algorithm. Simexpal can manage those variants without requiring
+you to duplicate the ``experiments`` stanza multiple times.
+
+Specifying Variants
+-------------------
+
+To specify variants we will use the following keys:
+
+- ``axis``: name of the variant axis
+- ``items``: list of dictionaries, which specify variants belonging to the same axis.
+
+For the variants in the ``items`` list we have to specify the
+
+- ``name``: name of the variant
+- ``extra_args``: list of variant arguments
+
+keys.
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to specify variants in the experiments.yml file.
+
+    variants:
+      - axis: 'block-algo'
+        items:
+          - name: 'ba-insert'
+            extra_args: ['insertion_sort']
+          - name: 'ba-bubble'
+            extra_args: ['bubble_sort']
+      - axis: 'block-size'
+        items:
+          - name: 'bs32'
+            extra_args: ['32']
+          - name: 'bs64'
+            extra_args: ['64']
+
+In this way we created the two variant axes ``block-algo`` and ``block-size``. The former
+axis has the variants ``ba-insert`` and ``ba-bubble`` and the latter has the variants
+``bs32`` and ``bs64``. If the ``extra_args`` contain more than one argument, e.g., a keyword
+argument ``--block-algo ba-insert``, then the arguments are stated separately in a list, i.e.
+``['--block-algo', 'ba-insert']``.
+
+Experiments will then be created from the cross product of the variants of each axis, i.e,
+``(ba-insert, bs32)``, ``(ba-insert, bs64)``, ``(ba-bubble, bs32)`` and ``(ba-bubble, bs32)``
+for the ``experiments.yml`` above.
+
+.. note::
+   The elements in each cross product will be sorted lexicographically. This plays a role when
+   the ``extra_args`` contain positional arguments as they are resolved in the order of the
+   elements in a cross product.
+
+Later we will see how to choose only certain combinations of variants (:ref:`RunMatrix`).
+
+Setting Environment Variables
+-----------------------------
+
+.. note::
+   Environment variables specified in variants will override the values of environment variables
+   specified in the ``experiments`` stanza (if the same variable occurs).
+
+Setting environment variables for variants works similar to
+:ref:`setting environment variables for experiments <ExperimentsSettingEnvironmentVariables>`.
+The difference is that we set the
+
+- ``environ``: dictionary of (environment variable, value)-pairs
+
+key for each item in the ``items`` key. For example you can specify the
+``OMP_NUM_THREADS`` environment variable as follows:
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to specify environment variables for variants in the experiments.yml file.
+
+   variants:
+     - axis: num_threads
+       items:
+         - name: ONT2
+           ...
+           environ:
+             OMP_NUM_THREADS: 2
+
+         - name: ONT4
+           ...
+           environ:
+             OMP_NUM_THREADS: 4
+
+Slurm: ``--ntasks-per-node``, ``-c``, ``-N``
+--------------------------------------------
+
+.. note::
+   Supported Slurm arguments specified in variants will override the values of supported Slurm
+   arguments specified in the ``experiments`` stanza (if the same slurm argument occurs).
+
+The :ref:`supported Slurm arguments in experiments <ExperimentsSupportedSlurmArgs>` are also
+supported for variants. Here, we can specify the
+
+- ``procs_per_node``: number of tasks to invoke on each node (slurm: ``--ntasks-per-node=n``)
+- ``num_threads``: number of cpus required per task (slurm: ``-c``, ``--cpus-per-task=ncpus``)
+- ``num_nodes``: number of nodes on which to run (N = min[-max]) (slurm: ``-N``, ``--nodes=N``)
+
+keys for each item in the ``items`` key.
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to specify supported Slurm parameters for variants in the experiments.yml file.
+
+   variants:
+     - axis: num_cores
+       items:
+         - name: c24
+           num_nodes: 1
+           procs_per_node: 24
+           num_threads: 2
+           extra_args: []           # empty extra_args as we only want to benchmark with
+                                    # different node/cpu settings; do NOT omit this key
+         - name: c48
+           num_nodes: 2
+           procs_per_node: 24
+           num_threads: 2
+           extra_args: []
+
+When launching your experiments with slurm, the variant ``c24`` will append
+``-N 1 --ntasks-per-node 24 -c 2`` to the sbatch command. Analogously for the experiment with
+the variant ``c48``.

--- a/docs/variants.rst
+++ b/docs/variants.rst
@@ -3,6 +3,14 @@
 Variants
 ========
 
+You might want to take a look at the following pages before exploring variants:
+
+- :ref:`QuickStart`
+- :ref:`AtVariables`
+- :ref:`Builds`
+- :ref:`Revisions`
+- :ref:`Experiments`
+
 When benchmarking algorithms, it is often useful to compare different variants or parameter
 configurations of the same algorithm. Simexpal can manage those variants without requiring
 you to duplicate the ``experiments`` stanza multiple times.
@@ -128,3 +136,9 @@ keys for each item in the ``items`` key.
 When launching your experiments with slurm, the variant ``c24`` will append
 ``-N 1 --ntasks-per-node 24 -c 2`` to the sbatch command. Analogously for the experiment with
 the variant ``c48``.
+
+Next
+----
+
+Now that you have entirely set up your experiments, you can modify the experiment combinations
+that you want to run. Visit the :ref:`RunMatrix` page for a detailed explanation.


### PR DESCRIPTION
This PR contains documentation for the following things:

- ``extra_paths`` key in ``builds`` stanza
- ``experiments`` key
- ``variants`` key
- ``matrix`` key
- reference for @-variables

It also contains some fixes for issues in the Quick Start guide.