### PR TITLE
Enhancement for 'output' key and addition of 'stdout' key in experiments stanza

### DIFF
--- a/scripts/simex
+++ b/scripts/simex
@@ -670,10 +670,13 @@ def do_experiments_purge(args):
 				util.try_rmfile(run.aux_file_path('lock'))
 				util.try_rmfile(run.aux_file_path('run'))
 				util.try_rmfile(run.aux_file_path('stderr'))
+				util.try_rmfile(run.aux_file_path('stdout'))
 				util.try_rmfile(run.aux_file_path('run.tmp'))
-				util.try_rmfile(run.output_file_path('out'))
 				util.try_rmfile(run.output_file_path('status'))
 				util.try_rmfile(run.output_file_path('status.tmp'))
+
+				for ext in run.experiment.info.output_extensions:
+					util.try_rmfile(run.output_file_path(ext))
 
 			else:
 				print("This would purge experiment '{}', instance '{}' [{}]. Use '-f' to confirm this action.".format(
@@ -695,7 +698,7 @@ def do_experiments_print_output(args):
 		for run in select_runs_from_cli(cfg, args, default_all=False):
 			print('Experiment: {}'.format(run.experiment.name))
 			print('Instance: {}'.format(run.instance.shortname))
-			print('Output:\n\n{}\n'.format(util.read_file(run.output_file_path('out'))))
+			print('Output:\n\n{}\n'.format(util.read_file(run.output_file_path_from_yml())))
 			print('Error Output:\n\n{}\n'.format(util.read_file(run.aux_file_path('stderr'))))
 
 experiments_print_parser = experiments_subcmds.add_parser('print',

--- a/scripts/simex
+++ b/scripts/simex
@@ -21,6 +21,9 @@ from simexpal.base import Status
 from simexpal.base import YmlLoader
 from itertools import zip_longest
 import yaml
+import warnings
+
+warnings.simplefilter(action='default', category=DeprecationWarning)  # do not ignore DeprecationWarnings
 
 colors = {
 	'red': '\x1b[31m',

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -1149,6 +1149,21 @@ class Run:
 
 		return Status.NOT_SUBMITTED
 
+	def output_file_path_from_yml(self):
+		def get_qualified_output_file(ext):
+			if ext not in self.experiment.info.output_extensions:
+				raise RuntimeError(
+					f"Unexpected output extension for experiment '{self.experiment.name}': .{ext}\n"
+				)
+			return self.output_file_path(ext)
+
+		if self.experiment.info.output == 'stdout':
+			return self.output_file_path('out')
+		elif self.experiment.info.stdout is not None:
+			return get_qualified_output_file(self.experiment.info.stdout)
+
+		return self.aux_file_path('stdout')
+
 	def open_output_file(self):
 		try:
 			return open(self.output_file_path('out'))

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -928,6 +928,17 @@ class ExperimentInfo:
 		return self._exp_yml.get('output', None)
 
 	@property
+	def output_extensions(self):
+		if 'output' in self._exp_yml:
+			if isinstance(self._exp_yml['output'], dict):
+				return self._exp_yml['output'].get('extensions', [])
+		return []
+
+	@property
+	def stdout(self):
+		return self._exp_yml.get('stdout', None)
+
+	@property
 	def workdir(self):
 		return self._exp_yml.get('workdir', None)
 

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -10,8 +10,6 @@ import warnings
 from . import instances
 from . import util
 
-warnings.simplefilter(action='default', category=DeprecationWarning)  # do not ignore DeprecationWarnings
-
 DEFAULT_DEV_BUILD_NAME = '_dev'
 EXPERIMENTS_LIST_THRESHOLD = 30
 TIMEOUT_GRACE_PERIOD = 30
@@ -931,8 +929,8 @@ class ExperimentInfo:
 	def output_extensions(self):
 		if 'output' in self._exp_yml:
 			if isinstance(self._exp_yml['output'], dict):
-				return self._exp_yml['output'].get('extensions', [])
-		return []
+				return set(self._exp_yml['output'].get('extensions', []) + ['out'])
+		return {'out'}
 
 	@property
 	def stdout(self):

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -1166,7 +1166,7 @@ class Run:
 
 	def open_output_file(self):
 		try:
-			return open(self.output_file_path('out'))
+			return open(self.output_file_path_from_yml())
 		except FileNotFoundError:
 			raise RuntimeError("The experiment '{}' with instance '{}' has not been started yet".format(
 				self.experiment.display_name, self.instance.shortname))

--- a/simexpal/schemes/experiments.json
+++ b/simexpal/schemes/experiments.json
@@ -215,7 +215,8 @@
 					},
 					"slurm_args": {"$ref": "#/definitions/str_or_str_list"},
 					"workdir": {"type": "string"},
-					"launcher": {"type": "string"}
+					"launcher": {"type": "string"},
+					"stdout": {"type": "string"}
 				},
 				"additionalProperties": false
 			}

--- a/simexpal/schemes/experiments.json
+++ b/simexpal/schemes/experiments.json
@@ -180,7 +180,18 @@
 					"name": {"type": "string"},
 					"args": {"$ref": "#/definitions/str_list"},
 					"use_builds": {"$ref": "#/definitions/str_list"},
-					"output": {"type": "string"},
+					"output": {
+						"oneOf": [
+							{"type": "string"},
+							{
+								"type": "object",
+								"properties": {
+									"extensions": {"$ref": "#/definitions/str_list"}
+								},
+								"additionalProperties": false
+							}
+						]
+					},
 					"num_nodes": {
 						"type": "integer",
 						"minimum": 1

--- a/simexpal/util.py
+++ b/simexpal/util.py
@@ -7,6 +7,7 @@ import sys
 import yaml
 import json
 from jsonschema import Draft7Validator
+import warnings
 
 def expand_at_params(s, fn, listfn=None):
 	def subfn(m):
@@ -110,6 +111,14 @@ def validate_setup_file(setup_file):
 		_validate_dict(launchers_yml_dict, "launchers.yml", schema_path)
 	except FileNotFoundError:
 		pass
+
+	for exp in exp_yml_dict.get('experiments', []):
+		if exp.get('output', None) == 'stdout':
+			msg = "Specifying the stdout path via 'output: stdout' is deprecated and will be removed in future " \
+					"versions. Use 'stdout: out' instead."
+			warnings.warn(msg, DeprecationWarning)
+
+			break
 
 	if 'instdir' not in exp_yml_dict:
 		exp_yml_dict['instdir'] = './instances'


### PR DESCRIPTION
This PR contains the following:
- It is possible to specify output extensions by adding the ``extensions`` key to the ``output`` dictionary, e.g. 
<pre>
output:
    extensions: [ext1, ext2]
</pre>
(``'out'`` will be added automatically)

- It is now possible to specify alternative output path extensions of experiments via the new ``stdout`` key by specifying the extension for the output file (the extensions has to be in the ``extensions`` list of ``output``), e.g.
```
experiments:
  - name: insertion-sort
    ...
    stdout: 'sol'
    output:
      extensions: ['sol']
```

 Then the results of the experiments will be written to 
``/path_to_exp_yml/output/<exp_name>~<variants>@<revision>/<inst_shortname>.sol``
- The new @-variable ``@OUTPUT:<ext>@`` is supported in the ``args`` key of experiments. This variable will resolve to ``/path_to_exp_yml/output/<exp_name>~<variants>@<revision>/<inst_shortname>.<ext>``
- Specifying ``'stdout'`` as value for the ``output`` key will trigger a DeprecationWarning
- ``simex e purge`` will now purge all respective output files (before, it would just purge the ``.out`` files)
- ``simex e print`` will now check the right output files for results (before, it would just check the ``.out`` files)
- ``Run.open_output_file()`` will now open the correct output file (before, it would just open the ``.out`` file)