### PR TITLE
 Change run selection in 'simex e', add documentation on CLI, and minor fixes

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -15,6 +15,49 @@ archive
 Archives all the experimental data into a ``data.tar.gz`` file within the same directory
 where the ``experiments.yml`` file is located.
 
+.. _cli_builds:
+
+builds
+------
+Responsible to download Git repositories and install executables.
+It supports the following actions:
+
+:make: downloads a Git repository and executes all build commands.
+:purge: deletes all related build files. To confirm this action it needs the ``-f`` argument.
+:remake: rebuilds a build from scratch.
+
+All the above actions can be applied to a subset of builds according to the ``--revisions`` and
+positional ``builds`` argument. Not specifying an argument will select all respective elements, e.g.,
+not specifying the ``--revisions`` argument will lead to the selection of every revision.
+
+develop
+-------
+Responsible to download Git repositories and install executables. It also allows you to redo arbitrary
+build steps after changing local Git files to take over the local changes.
+
+The ``develop`` action can be applied to a subset of builds according to the ``--revisions`` and
+positional ``builds`` argument (analogously to how it works for the :ref:`simex builds <cli_builds>`
+command above).
+
+It further supports the following additional arguments:
+
+:``--checkout``: deletes the local Git repository and (re-)clones it.
+:``--compile``: (re-)compiles the build.
+:``--configure``: (re-)configures the build.
+:``--delete-source``: deletes the source directory when purging.
+:``--install``: (re-)installs the build.
+:``--purge``: deletes all related build files.
+:``--recheckout``: deletes the local build Git repository, reclones, regenerates, reconfigures, recompiles
+    and reinstalls it.
+:``--recompile``: recompiles and reinstall the build.
+:``--reconfigure``: reconfigures, recompiles and reinstalls the build.
+:``--regenerate``: (re-)regenerates the build.
+:``--reinstall``: reinstalls the build.
+:``--reregenerate``: regenerates, reconfigures, recompiles and reinstalls the build.
+
+The ``--checkout``, ``--recheckout`` and ``--purge`` arguments further require the ``-f`` argument to confirm
+their actions.
+
 experiments
 -----------
 Responsible to check, execute and remove experiments.

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -10,6 +10,44 @@ Simexpal instructions are written as:
 
 In the following, we list all simexpal instructions and their arguments.
 
+archive
+-------
+Archives all the experimental data into a ``data.tar.gz`` file within the same directory
+where the ``experiments.yml`` file is located.
+
+experiments
+-----------
+Responsible to check, execute and remove experiments.
+It supports the following actions:
+
+:info: displays all related instances, instance sets, variant axes and variants of experiments
+   on the command-line.
+:list: lists all the experiments.
+   Executed experiments are shown in green, failed ones are shown in red, running ones in
+   yellow, and the non executed ones in the default command-line color. With the argument
+   ``--detailed`` it will show every single run. With ``--compact`` all runs with the same
+   experiment will be grouped together. The ``--full`` option forces simexpal to display the
+   full experiment name.
+:launch: launches all the non executed experiments.
+:purge: deletes the experimental data. To confirm this action it needs the ``-f`` argument.
+:print: displays all experimental output, including error outputs, on the command-line.
+
+All the above actions can be applied to a subset of experiments according to a `selection option`,
+which can be specified as an additional argument. Supported selection options are:
+
+:``--all``: selects all the experiments.
+:``--axes [axes...]``: selects all experiments with the variant axes from the space separated list of axes.
+:``--run <r>``: selects the single run given as ``<experiment_display_name>/<instance>``, where
+    ``<experiment_display_name>`` is the name of the experiment as displayed on the command-line and
+    ``<instance>`` is the instance name as displayed on the command-line.
+:``--experiment <e>``: selects the experiment named ``e``.
+:``--failed``: selects all the failed experiments.
+:``--instance <i>``: selects all experiments with the instance named ``i``.
+:``--instset <i>``: selects all experiments with the instance set named ``i``.
+:``--unfinished``: selects all the unfinished experiments.
+:``--revision <i>``: selects all experiments with the revision named ``r``.
+:``--variants [variants...]``: selects all experiments with the variants from the space separated list of variants.
+
 instances
 ---------
 Checks and eventually downloads the instances for the experiments.
@@ -23,34 +61,3 @@ It supports the following actions:
 :process: caches information about instances.
 :run-transform: manually runs a transformation on instance files.
 
-experiment
-----------
-Responsible to check, execute and remove experiments.
-It supports the following actions:
-
-:list: lists all the experiments.
-   Executed experiments are shown in green, failed ones are shown in red, running ones in
-   yellow, and the non executed ones in the default command-line color.
-:launch: launches all the non executed experiments.
-:purge: removes the experimental data.
-   To actually delete experimental data, this instruction needs a further option ``-f``.
-   Otherwise it will just perform a dry run.
-
-All the above actions can be applied to a subset of experiments according to a `selection option`,
-which can be specified as an additional argument ``--[selection option]``.
-Supported selection options are:
-
-:``all``: selects all the experiments.
-:``failed``: selects all the failed experiments.
-:``unfinished``: selects all the unfinished experiments.
-:``experiment <e>``: selects the experiment named `e`.
-
-..
-    builds
-    ------
-    TODO
-
-archive
--------
-Archives all the experimental data into a ``data.tar.gz`` file within the same directory
-where the ``experiments.yml`` file is located.

--- a/scripts/simex
+++ b/scripts/simex
@@ -664,7 +664,7 @@ def do_experiments_launch(args):
 	for run in select_runs_from_cli(cfg, args):
 		if not run.instance.check_available():
 			print("Skipping run {}/{}[{}] as instance is not available".format(
-					run.experiment.name, run.instance.shortname, run.repetition))
+					run.experiment.display_name, run.instance.shortname, run.repetition))
 			continue
 
 		if args.launcher:
@@ -717,11 +717,9 @@ def do_experiments_purge(args):
 		return
 	else:
 		for run in select_runs_from_cli(cfg, args, default_all=False):
-			(exp, instance) = (run.experiment, run.instance.shortname)
-
 			if args.f:
-				print("Purging experiment '{}', instance '{}' [{}]".format(
-						exp.name, instance, run.repetition))
+				print("Purging run {}/{}[{}]".format(
+						run.experiment.display_name, run.instance.shortname, run.repetition))
 
 				util.try_rmfile(run.aux_file_path('lock'))
 				util.try_rmfile(run.aux_file_path('run'))
@@ -737,8 +735,8 @@ def do_experiments_purge(args):
 				run.purge_status_cache_dict()
 
 			else:
-				print("This would purge experiment '{}', instance '{}' [{}]. Use '-f' to confirm this action.".format(
-						exp.name, instance, run.repetition))
+				print("This would purge run {}/{}[{}]. Use '-f' to confirm this action.".format(
+						run.experiment.display_name, run.instance.shortname, run.repetition))
 
 	cfg.writeback_status_cache()
 

--- a/scripts/simex
+++ b/scripts/simex
@@ -678,7 +678,7 @@ def do_experiments_launch(args):
 			queue = default_yml['queue'] if 'queue' in default_yml else None
 			append_to_launchers_dict(default_yml['name'], run, default_yml['scheduler'], queue)
 		else:
-			# Final fallback: use the the fork()-based launcher.
+			# Final fallback: use the fork()-based launcher.
 			append_to_launchers_dict('_fork', run, 'fork')
 
 	for launcher, launcher_runs in launchers.values():

--- a/scripts/simex
+++ b/scripts/simex
@@ -6,6 +6,7 @@
 import argparse
 import os
 import argcomplete
+import re
 import sys
 
 import simexpal as extl
@@ -43,6 +44,12 @@ main_parser.add_argument('-C', type=str)
 main_subcmds = main_parser.add_subparsers(metavar='<command>')
 main_subcmds.required = True
 
+run_regex = re.compile(r'(?P<experiment>[^~@/\[\]]+)'
+						r'(~(?P<variants>[^~@/\[\]]+))?'
+						r'(@(?P<revision>[^~@/\[\]]+))?'
+						r'(/(?P<instance>[^~@/\[\]]+))'
+						r'(\[(?P<repetition>\d+)\])?')
+
 def cli_selects_run(args, run):
 	if args.experiment is not None:
 		if args.experiment != run.experiment.name:
@@ -51,8 +58,7 @@ def cli_selects_run(args, run):
 		if args.instance != run.instance.shortname:
 			return False
 	if args.revision is not None:
-		if (run.experiment.revision is None
-				or args.revision != run.experiment.revision.name):
+		if run.experiment.revision is None or args.revision != run.experiment.revision.name:
 			return False
 	if args.variants is not None:
 		exp_variants = [var.name for var in run.experiment.variation]
@@ -68,7 +74,45 @@ def cli_selects_run(args, run):
 		if args.instset not in run.instance.instsets:
 			return False
 	if args.run is not None:
-		if args.run != run.experiment.name + '/' + run.instance.shortname:
+		m = run_regex.search(args.run)
+		if m is None:
+			raise RuntimeError("The input for the '--run' argument can not be parsed. Please provide the input in the "
+								"following format: "
+								"'<experiment_name>~<variants>@<revision_name>/<instance_name>[<repetition>]'. "
+								"'~<variants>', '@<revision_name>' and '[<repetition>]' are optional, where <variants> "
+								"is a comma separated list of variant names: {} ".format(args.run))
+
+		exp = m.group('experiment').strip()
+		if exp != run.experiment.name:
+			return False
+
+		variants = m.group('variants')
+		if variants is not None:
+			variants = variants.split(',')
+			variants = sorted([v.strip() for v in variants])
+
+			exp_variants = sorted([var.name for var in run.experiment.variation])
+
+			if variants != exp_variants:
+				return False
+
+		revision = m.group('revision')
+		if revision is not None:
+			revision = revision.strip()
+			if run.experiment.revision is None or revision != run.experiment.revision.name:
+				return False
+		elif args.revision is not None:
+			return False
+
+		instance = m.group('instance').strip()
+		if instance != run.instance.shortname:
+			return False
+
+		repetition = m.group('repetition')
+		if repetition is not None:
+			if int(repetition) != run.repetition:
+				return False
+		elif run.repetition != 0:
 			return False
 	if args.failed:
 		if not run.get_status().is_negative:
@@ -108,9 +152,11 @@ run_selection_parser.add_argument('--instset', type=str)
 run_selection_parser.add_argument('--experiment', type=str)
 run_selection_parser.add_argument('--instance', type=str)
 run_selection_parser.add_argument('--revision', type=str)
-run_selection_parser.add_argument('--variants', type=str, nargs='+', help='name of different variants (space separated)')
-run_selection_parser.add_argument('--axes', type=str, nargs='+', help='name of different variant axes (space separated)')
-run_selection_parser.add_argument('--run', type=str, help='given as experiment/instance')
+run_selection_parser.add_argument('--variants', type=str, nargs='+', help='Name of different variants (space separated)')
+run_selection_parser.add_argument('--axes', type=str, nargs='+', help='Name of different variant axes (space separated)')
+run_selection_parser.add_argument('--run', type=str, help="Given as "
+	"'<experiment_name>~<variants>@<revision_name>/<instance_name>[<repetition>]', where '~<variants>', '@<revision_name>' "
+	"and '[<repetition>]' are optional and '<variants>' is a comma separated list of variant names")
 run_selection_parser.add_argument('--all', action='store_true')
 run_selection_parser.add_argument('--failed', action='store_true')
 run_selection_parser.add_argument('--unfinished', action='store_true')

--- a/scripts/simex
+++ b/scripts/simex
@@ -73,6 +73,9 @@ def cli_selects_run(args, run):
 	if args.instset is not None:
 		if args.instset not in run.instance.instsets:
 			return False
+	if args.repetition is not None:
+		if args.repetition != run.repetition:
+			return False
 	if args.run is not None:
 		m = run_regex.search(args.run)
 		if m is None:
@@ -140,6 +143,7 @@ def can_select_runs_from_cli(args):
 			or args.instset is not None
 			or args.variants is not None
 			or args.axes is not None
+			or args.repetition is not None
 			or args.run is not None
 			or args.all
 			or args.failed
@@ -154,6 +158,7 @@ run_selection_parser.add_argument('--instance', type=str)
 run_selection_parser.add_argument('--revision', type=str)
 run_selection_parser.add_argument('--variants', type=str, nargs='+', help='Name of different variants (space separated)')
 run_selection_parser.add_argument('--axes', type=str, nargs='+', help='Name of different variant axes (space separated)')
+run_selection_parser.add_argument('--repetition', type=int, help='')
 run_selection_parser.add_argument('--run', type=str, help="Given as "
 	"'<experiment_name>~<variants>@<revision_name>/<instance_name>[<repetition>]', where '~<variants>', '@<revision_name>' "
 	"and '[<repetition>]' are optional and '<variants>' is a comma separated list of variant names")

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -96,6 +96,11 @@ class Config:
 			if name.startswith('_'):
 				raise RuntimeError(f"Names starting with an underscore are reserved for internal simexpal objects: {name}")
 
+			forbidden_chars = [' ', '~', '@', '/', '[', ']']
+			for c in forbidden_chars:
+				if c in name:
+					raise RuntimeError(f"The character '{c}' is not allowed in names for simexpal objects: {name}")
+
 		def construct_instances():
 			if 'instances' in self.yml:
 				for inst_yml in self.yml['instances']:

--- a/simexpal/build.py
+++ b/simexpal/build.py
@@ -125,7 +125,7 @@ def make_build_in_order(cfg, build, wanted_builds, wanted_phases):
 
 	# Build the environment.
 	def prepend_env(var, items):
-		if(var in os.environ):
+		if var in os.environ:
 			return ':'.join(items) + ':' + os.environ[var]
 		return ':'.join(items)
 

--- a/simexpal/instances.py
+++ b/simexpal/instances.py
@@ -74,10 +74,10 @@ def convert_to_edgelist(inst_yml, in_path, out_path):
 
 	if repo == 'konect':
 		separator = ' '
-		commentPrefix = '%'
+		comment_prefix = '%'
 	elif repo == 'snap':
 		separator = '\t'
-		commentPrefix = '#'
+		comment_prefix = '#'
 
 	def get_other_separator(separator):
 		if separator == ' ':
@@ -86,7 +86,7 @@ def convert_to_edgelist(inst_yml, in_path, out_path):
 	with open(in_path, 'r') as in_f:
 		with open(out_path, 'w') as out_f:
 			for line in in_f:
-				if line.startswith(commentPrefix):
+				if line.startswith(comment_prefix):
 					continue
 				split_line = line.strip().split(separator)
 				if len(split_line) < 2:

--- a/simexpal/launch/fork.py
+++ b/simexpal/launch/fork.py
@@ -7,8 +7,8 @@ class ForkLauncher(common.Launcher):
 			return
 		common.create_run_file(run)
 
-		print("Launching experiment '{}', instance '{}' on local machine".format(
-				run.experiment.name, run.instance.shortname))
+		print("Launching run {}/{}[{}] on local machine".format(
+				run.experiment.display_name, run.instance.shortname, run.repetition))
 		manifest = common.compile_manifest(run)
 		common.invoke_run(manifest)
 

--- a/simexpal/launch/queue.py
+++ b/simexpal/launch/queue.py
@@ -22,8 +22,8 @@ class QueueLauncher(common.Launcher):
 		with os.fdopen(specfd, 'w') as f:
 			util.write_yaml_file(f, specs)
 
-		print("Launching experiment '{}', instance '{}' on local machine".format(
-				run.experiment.name, run.instance.shortname))
+		print("Launching run {}/{}[{}] on local machine".format(
+				run.experiment.display_name, run.instance.shortname, run.repetition))
 
 		queuesock.sendrecv({
 			'action': 'launch',

--- a/simexpal/launch/sge.py
+++ b/simexpal/launch/sge.py
@@ -35,8 +35,8 @@ class SgeLauncher(common.Launcher):
 			if not common.lock_run(r):
 				return
 			locked = [r]
-			print("Launching experiment '{}', instance '{}' on SGE queue '{}'".format(
-					r.experiment.name, r.instance.shortname, self.queue))
+			print("Launching run {}/{}[{}] on SGE queue '{}'".format(
+					r.experiment.display_name, r.instance.shortname, r.repetition, self.queue))
 
 			invoke_args.extend(['--experiment', r.experiment.name,
 					'--instance', r.instance.shortname,
@@ -46,8 +46,8 @@ class SgeLauncher(common.Launcher):
 			for run in r:
 				if not common.lock_run(run):
 					continue
-				print("Launching experiment '{}', instance '{}' on SGE queue '{}'".format(
-						run.experiment.name, run.instance.shortname, self.queue))
+				print("Launching run {}/{}[{}] on SGE queue '{}'".format(
+						run.experiment.display_name, run.instance.shortname, run.repetition, self.queue))
 				locked.append(run)
 
 			if not locked:

--- a/simexpal/launch/slurm.py
+++ b/simexpal/launch/slurm.py
@@ -97,11 +97,11 @@ class SlurmLauncher(common.Launcher):
 		# Finally start the run.
 		for run in locked:
 			if self.queue:
-				print("Submitting experiment '{}', instance '{}' to slurm partition '{}'".format(
-						run.experiment.name, run.instance.shortname, self.queue))
+				print("Submitting run {}/{}[{}] to slurm partition '{}'".format(
+						run.experiment.display_name, run.instance.shortname, run.repetition, self.queue))
 			else:
-				print("Submitting experiment '{}', instance '{}' to default slurm partition".format(
-						run.experiment.name, run.instance.shortname))
+				print("Submitting run {}/{}[{}] to default slurm partition".format(
+						run.experiment.display_name, run.instance.shortname, run.repetition))
 
 		process = subprocess.Popen(sbatch_args, stdin=subprocess.PIPE)
 		process.communicate(sbatch_script.encode())  # Assume UTF-8 encoding here.


### PR DESCRIPTION
The PR contains the following:
- ~``args.run`` will now be compared to ``run.experiment.display_name + '/' + run.instance.shortname`` instead of ``run.experiment.name + '/' + run.instance.shortname``~
- ``--run`` will now be parsed into experiment, variants, revision, instance and repetition
- ``--repetition``was added to the ``run_selection_parser``
- logging messages when launching/skipping/purging a run are now more detailed
- ``Config.check_for_reserved_name()`` will also check for characters in ``[' ', '~', '@', '/', '[', ']']`` and raise a ``RuntimeError`` if they are detected
- updated documentation of 'experiments'  and added sections on 'builds' and 'develop' in command-line reference
- minor fixes (typos, redundant parentheses, rename variable)