### PR TITLE
Added contents of the scheme directory to package_data in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
 
 	# Now, set the actual Python configuration.
 	packages=['simexpal', 'simexpal.launch'],
+	package_data={'simexpal': ['schemes/*.json']},
 	scripts=['scripts/simex'],
 	install_requires=[
 		'argcomplete',


### PR DESCRIPTION
When installing simexpal using pip and calling `simex develop`, I get the following error:
```
Traceback (most recent call last):
  File "/vol/tmp/martinro/venv/expalgo/bin/simex", line 853, in <module>
    main_args.cmd(main_args)
  File "/vol/tmp/martinro/venv/expalgo/bin/simex", line 342, in do_develop
    cfg = extl.base.config_for_dir()
  File "/vol/tmp/martinro/venv/expalgo/lib64/python3.6/site-packages/simexpal/base.py", line 1276, in config_for_dir
    yml = read_and_validate_setup(basedir=basedir)
  File "/vol/tmp/martinro/venv/expalgo/lib64/python3.6/site-packages/simexpal/base.py", line 1271, in read_and_validate_setup
    return util.validate_setup_file(os.path.join(basedir, setup_file))
  File "/vol/tmp/martinro/venv/expalgo/lib64/python3.6/site-packages/simexpal/util.py", line 106, in validate_setup_file
    _validate_dict(exp_yml_dict, "experiments.yml", schema_path)
  File "/vol/tmp/martinro/venv/expalgo/lib64/python3.6/site-packages/simexpal/util.py", line 88, in _validate_dict
    with open(schema_path, 'r') as f:
FileNotFoundError: [Errno 2] No such file or directory: '/vol/tmp/martinro/venv/expalgo/lib64/python3.6/site-packages/simexpal/schemes/experiments.json'
```
The reason is, that the contents of `simexpal/schemes` are not part of the package installation.

This pull request fixes that by adding
```
package_data={'simexpal': ['schemes/*.json']}
```
to the setup function in `setup.py`
