### PR TITLE
Remove 'extra_args' from required keys in variants

### DIFF
--- a/simexpal/schemes/experiments.json
+++ b/simexpal/schemes/experiments.json
@@ -233,7 +233,7 @@
 						"type": "array",
 						"items": {
 							"type": "object",
-							"required": ["name", "extra_args"],
+							"required": ["name"],
 							"properties": {
 								"name": {"type": "string"},
 								"extra_args": {"$ref":  "#/definitions/str_list"},


### PR DESCRIPTION
Fix issue #82.