### PR TITLE
fileless instances (issue #78) and instances with extra arguments

### DIFF
--- a/docs/at_variables_reference.rst
+++ b/docs/at_variables_reference.rst
@@ -17,7 +17,7 @@ specify ``experiments.py @INSTANCE@`` as experiment arguments.
 Below, we list all @-variables and where they can be used.
 
 - ``@COMPILE_DIR_FOR:<build_name>@``: :ref:`compilation directory <BuildDirectories>` of ``<build_name>`` in the same revision
-- ``@EXTRA_ARGS@``: extra arguments of all variants of an experiment
+- ``@EXTRA_ARGS@``: extra arguments of all variants and the instance of an experiment
 - ``@INSTANCE@``: path of a :ref:`local <LocalInstances>`/:ref:`remote <RemoteInstances>` instance, i.e. ``/instance_directory/<instance_name>``
 - ``@INSTANCE:<ext>@``: path of a :ref:`MultipleExtensions` instance with extension ``<ext>``, i.e. ``/instance_directory/<instance_name>.<ext>``
 - ``@INSTANCE:<idx>@``: path of an :ref:`ArbitraryInputFiles` instance with index ``<idx>`` in the ``files`` key, i.e. ``/instance_directory/files[<idx>]``

--- a/docs/experiments.rst
+++ b/docs/experiments.rst
@@ -52,6 +52,12 @@ a list of strings (instead of one space separated string). Note that the :ref:`@
 ``@INSTANCE@`` resolves to the paths of the instances given in the ``instances`` stanza, i.e,
 ``/instance_directory/<instance_name>``.
 
+If the instances have :ref:`InstanceExtraArguments`, we further need to add the :ref:`@-variable <AtVariables>`
+``@EXTRA_ARGS@`` to the experiment arguments, e.g,
+``args: ['./sort.py', '--algo=insertion-sort', '@INSTANCE@', '@EXTRA_ARGS@']`` for the example above.
+``@EXTRA_ARGS@`` will resolve to the specified extra arguments of the respective instance (and also the used
+:ref:`variants <ExperimentsWithVariants>`, see below).
+
 .. _ExperimentsWithMultipleExtensionInstances:
 
 Experiments with Multiple Extension Instances
@@ -78,6 +84,8 @@ specify your experiment as follows:
 The ``@INSTANCE:graph@`` variable will resolve to ``/instance_directory/<instance_name>.graph`` during
 runtime. Analogously for the ``@INSTANCE:xyz@`` variable.
 
+:ref:`InstanceExtraArguments` are handled analogously to the case of :ref:`ExperimentsWithLocalRemoteInstances`.
+
 Experiments with Arbitrary Input File Instances
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -103,6 +111,10 @@ as follows:
 The ``@INSTANCE:0@`` variable will resolve to ``/instance_directory/files[0]``, where ``files[0]`` is
 the first filename of the ``files`` key. Analogously for the ``@INSTANCE:1`` variable.
 
+:ref:`InstanceExtraArguments` are handled analogously to the case of :ref:`ExperimentsWithLocalRemoteInstances`.
+
+.. _ExperimentsWithVariants:
+
 Experiments with Variants
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -118,8 +130,8 @@ arguments:
        args: ['./algorithm.py', '@INSTANCE@', '@EXTRA_ARGS@']
        output: stdout
 
-The ``@EXTRA_ARGS@`` variable resolves to the extra arguments of all variants of the experiment during runtime.
-For example, assume we have the following ``variants`` stanza:
+The ``@EXTRA_ARGS@`` variable resolves to the extra arguments of all variants (and also the used instance, see
+above) of the experiment during runtime. For example, assume we have the following ``variants`` stanza:
 
 .. code-block:: YAML
    :linenos:

--- a/docs/instances.rst
+++ b/docs/instances.rst
@@ -157,6 +157,91 @@ The ``experiments.yml`` file above will create the instance ``foo`` which contai
 ``file1`` and ``file2`` and the instance ``bar`` which contains the files
 ``file3`` and ``file4``.
 
+Fileless Instances
+------------------
+
+There are cases where instances are not defined by a file but rather by some input parameters, e.g.
+algorithms that generate their data themselves and only need input parameters like ``--seed 10``.
+Specifying fileless instances works similar to specifying :ref:`ArbitraryInputFiles`. The difference is,
+that we set ``files: []`` to indicate that we are dealing with a fileless instance and use the
+
+- ``extra_args``:  list of extra arguments
+
+key to specify our extra arguments.
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to list fileless instances in the experiments.yml file.
+
+    instances:
+      - repo: local
+        items:
+          - name: foo
+            files: []
+            extra_args: ['--seed', '10']
+
+.. _InstanceExtraArguments:
+
+Extra Arguments
+---------------
+
+We can set extra arguments for instances, which can be appended to the experiment arguments when the
+respective instance is used. In order to specify such instances, we use the
+
+- ``extra_args``: list of extra arguments
+
+key.
+
+For :ref:`LocalInstances`, :ref:`RemoteInstances` and :ref:`MultipleExtensions` we need to change
+the ``items`` key from a list of instances to a list of dictionaries containing the
+
+- ``name``: name of the instance `and`
+- ``extra_args``
+
+key, e.g.,
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to list local/remote/multiple extension instances with extra arguments in the experiments.yml file.
+
+   instances:
+     - repo: local # local instances with extra arguments
+       items:
+         - name: inst1
+           extra_args: ['some','extra_args']
+         - name: inst2
+           extra_args: ['some','extra_args']
+     - repo: snap # remote instances with extra arguments
+       items:
+         - name: facebook_combined
+           extra_args: ['some', 'extra', 'argument']
+         - name: wiki-Vote
+           extra_args: ['some', 'extra', 'argument']
+     - repo: local # multiple extension instances with extra args
+       items:
+         - name: inst3
+           extra_args: ['some', 'extra', 'argument']
+         - name: inst4
+           extra_args: ['some', 'extra', 'argument']
+       extensions: [ext1, ext2]
+
+For :ref:`ArbitraryInputFiles` we only need to add the ``extra_args`` key
+to the dictionaries of the instances, e.g,
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to list arbitrary input file instances with extra arguments in the experiments.yml file.
+
+    instances:
+     - repo: local
+       items:
+         - name: inst3
+           files: [file1, file2]
+           extra_args: ['some', 'extra', 'argument']
+         - name: inst4
+           files: [file1, file2]
+           extra_args: ['some', 'extra', 'argument']
+
 .. _InstanceSets:
 
 Instance Sets

--- a/scripts/simex
+++ b/scripts/simex
@@ -266,6 +266,9 @@ def do_instances_process(args):
 		if len(inst.filenames) > 1:
 			print("Skipping instance '{}' as it does not have a unique filename".format(inst.shortname))
 			continue
+		if inst.is_fileless:
+			print("Skipping fileless instance '{}'".format(inst.shortname))
+			continue
 		if os.access(os.path.join(cfg.instance_dir(), inst.shortname + '.info'), os.F_OK):
 			continue
 

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -582,6 +582,12 @@ class Instance:
 		return self._inst_yml['extensions']
 
 	@property
+	def extra_args(self):
+		if isinstance(self._inst_yml['items'][self.index], dict):
+			return self._inst_yml['items'][self.index].get('extra_args', [])
+		return []
+
+	@property
 	def config(self):
 		return self._cfg
 

--- a/simexpal/launch/common.py
+++ b/simexpal/launch/common.py
@@ -146,6 +146,7 @@ class RunManifest:
 		extra_args = []
 		for var_yml in self.yml['variants']:
 			extra_args.extend(var_yml['extra_args'])
+		extra_args.extend(self.yml['instance_extra_args'])
 		return extra_args
 
 	def get_paths(self):
@@ -259,6 +260,7 @@ def compile_manifest(run):
 		'instance_name': run.instance.yml_name,
 		'instance_extensions': instance_extensions,
 		'instance_files': instance_files,
+		'instance_extra_args': run.instance.extra_args,
 		'repetition': run.repetition,
 		'builds': builds_dict,
 		'args': exp.info.args,

--- a/simexpal/launch/common.py
+++ b/simexpal/launch/common.py
@@ -67,8 +67,8 @@ class RunManifest:
 		return self.yml['instance']
 
 	@property
-	def instance_yml_name(self):
-		return self.yml['instance_filename']
+	def instance_name(self):
+		return self.yml['instance_name']
 
 	@property
 	def instance_extensions(self):
@@ -256,7 +256,7 @@ def compile_manifest(run):
 		'variants': variants_yml,
 		'revision': exp.revision.name if exp.revision else None,
 		'instance': run.instance.shortname,
-		'instance_filename': run.instance.yml_name,
+		'instance_name': run.instance.yml_name,
 		'instance_extensions': instance_extensions,
 		'instance_files': instance_files,
 		'repetition': run.repetition,
@@ -320,11 +320,11 @@ def invoke_run(manifest):
 				raise RuntimeError(
 					f"Unexpected file extension for instance '{manifest.instance}': .{identifier}"
 				) from None
-			return ''.join([manifest.instance_dir, '/', manifest.instance_yml_name, '.', identifier])
+			return ''.join([manifest.instance_dir, '/', manifest.instance_name, '.', identifier])
 
 	def substitute(p):
 		if p == 'INSTANCE':
-			return manifest.instance_dir + '/' + manifest.instance_yml_name
+			return manifest.instance_dir + '/' + manifest.instance_name
 		elif p.startswith('INSTANCE:'):
 			return get_qualified_filename(p.split(':')[1])
 		elif p == 'REPETITION':

--- a/simexpal/schemes/experiments.json
+++ b/simexpal/schemes/experiments.json
@@ -83,91 +83,191 @@
 			"type": "array",
 			"items": {
 				"type": "object",
-				"required": ["items"],
-				"properties": {
-					"repo": {
-						"type": "string",
-						"enum": ["local", "konect", "snap"]
-					},
-					"repo-subdir": {"type": "string"},
-					"generator": {"type": "object"},
-					"extensions": {"$ref": "#/definitions/str_list"},
-					"items": {
-						"oneOf": [
-							{"$ref": "#/definitions/dict_list"},
-							{"$ref": "#/definitions/str_list"}
-						]
-					},
-					"set": {"$ref": "#/definitions/str_or_str_list"}
-				},
-				"additionalProperties": false,
-				"if": {
-					"properties": {
-						"generator": {"type": "object"}
-					},
-					"required": ["generator"]
-				},
-				"then": {
-					"properties": {
-						"generator": {
-							"type": "object",
-							"required": ["args"],
-							"properties": {
-								"args": {"$ref": "#/definitions/str_list"},
-								"postprocess": {"const": "to_edgelist"}
-							},
-							"additionalProperties": false
-						},
-						"items": {"$ref": "#/definitions/str_list"},
-						"repo": false,
-						"extensions": false
-					}
-				},
-				"else": {
-					"if": {
-						"properties": {
-							"repo": {"const": "local"}
-						},
-						"required": ["repo"]
-					},
-					"then": {
+				"allOf": [
+					{
 						"if": {
+							"required": ["generator"],
 							"properties": {
-								"items": {"$ref": "#/definitions/dict_list"}
+								"generator": {"type": "object"}
 							}
 						},
 						"then": {
+							"required": ["generator", "items"],
+							"properties": {
+								"generator": {
+									"type": "object",
+									"required": ["args"],
+									"properties": {
+										"args": {"$ref": "#/definitions/str_list"}
+									},
+									"additionalProperties": false
+								},
+								"set": {"$ref": "#/definitions/str_or_str_list"},
+								"items": {
+									"oneOf": [
+										{
+											"$ref": "#/definitions/str_list"
+										},
+										{
+											"type": "array",
+											"items": {
+												"type": "object",
+												"required": ["name"],
+												"properties": {
+													"name": {"type": "string"},
+													"extra_args": {"$ref": "#/definitions/str_list"}
+												},
+												"additionalProperties": false
+											}
+										}
+									]
+								}
+							},
+							"additionalProperties": false
+						}
+					},
+					{
+						"if": {
+							"required": ["extensions"],
+							"properties": {
+								"extensions": {"$ref": "#/definitions/str_list"}
+							}
+						},
+						"then": {
+							"required": ["repo", "extensions", "items"],
+							"properties": {
+								"repo": {"const": "local"},
+								"extensions": {"$ref": "#/definitions/str_list"},
+								"set": {"$ref": "#/definitions/str_or_str_list"},
+								"items": {
+									"oneOf": [
+										{
+											"$ref": "#/definitions/str_list"
+										},
+										{
+											"type": "array",
+											"items": {
+												"type": "object",
+												"required": ["name"],
+												"properties": {
+													"name": {"type": "string"},
+													"extra_args": {"$ref": "#/definitions/str_list"}
+												},
+												"additionalProperties": false
+											}
+										}
+									]
+								}
+							},
+							"additionalProperties": false
+						}
+					},
+					{
+						"if": {
+							"required": ["items"],
 							"properties": {
 								"items": {
 									"type": "array",
 									"items": {
 										"type": "object",
-										"required": ["name","files"],
+										"required": ["files"],
 										"properties": {
-											"name": {"type": "string"},
 											"files": {"$ref": "#/definitions/str_list"}
 										}
 									}
-								},
-								"extensions": false,
-								"generator": false
+								}
 							}
 						},
-						"else": {
+						"then": {
+							"required": ["repo", "items"],
 							"properties": {
-								"extensions": {"$ref": "#/definitions/str_list"},
-								"items": {"$ref": "#/definitions/str_list"},
-								"generator": false
-							}
+								"repo": {"const": "local"},
+								"set": {"$ref": "#/definitions/str_or_str_list"},
+								"items": {
+									"type": "array",
+									"items": {
+										"type": "object",
+										"required": ["name", "files"],
+										"properties": {
+											"name": {"type": "string"},
+											"files": {"$ref": "#/definitions/str_list"},
+											"extra_args": {"$ref": "#/definitions/str_list"}
+										},
+										"additionalProperties": false
+									}
+								}
+							},
+							"additionalProperties": false
 						}
 					},
-					"else": {
-						"properties": {
-							"items": {"$ref": "#/definitions/str_list"},
-							"generator": false
+					{
+						"if": {
+							"not": {
+								"anyOf": [
+									{
+										"required": ["generator"],
+										"properties": {
+											"generator": {"type": "object"}
+										}
+									},
+									{
+										"required": ["extensions"],
+										"properties": {
+											"extensions": {"$ref": "#/definitions/str_list"}
+										}
+									},
+									{
+										"required": ["items"],
+										"properties": {
+											"items": {
+												"type": "array",
+												"items": {
+													"type": "object",
+													"required": ["files"],
+													"properties": {
+														"files": {"$ref": "#/definitions/str_list"}
+													}
+												}
+											}
+										}
+									}
+								]
+							}
+						},
+						"then": {
+							"required": ["repo", "items"],
+							"properties": {
+								"repo": {
+									"type": "string",
+									"enum": ["local", "konect", "snap"]
+								},
+								"repo-subdir": {"type": "string"},
+								"postprocess": {"const": "to_edgelist"},
+								"set": {"$ref": "#/definitions/str_or_str_list"},
+								"items": {
+									"oneOf": [
+										{
+											"$ref": "#/definitions/str_list"
+										},
+										{
+											"type": "array",
+											"items": {
+												"type": "object",
+												"required": ["name"],
+												"properties": {
+													"name": {"type": "string"},
+													"extra_args": {"$ref": "#/definitions/str_list"}
+												},
+												"additionalProperties": false
+											}
+										}
+									]
+								}
+							},
+							"additionalProperties": false
 						}
 					}
-				}
+				]
 			}
 		},
 		"experiments": {

--- a/simexpal/util.py
+++ b/simexpal/util.py
@@ -97,6 +97,19 @@ def validate_setup_file(setup_file):
 
 				print("simexpal: Validation error in {} at {}:\n{}\n{}".format(
 					source, err_source, err.instance, err.message), file=sys.stderr, end="\n\n")
+
+				# The error comes from subschemas in anyOf, oneOf or allOf.
+				if err.context:
+					print("Below are the validation errors of each respective subschema:")
+
+					schema_index = None
+					for sub_error in sorted(err.context, key=lambda e: e.schema_path[0]):
+						cur_schema_index = sub_error.schema_path[0]
+						if cur_schema_index != schema_index:
+							schema_index = cur_schema_index
+							print("\nValidation errors in subschema [{}]:".format(cur_schema_index))
+						print(sub_error.message)
+					print()
 			sys.exit(1)
 
 	cur_file_path = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
This PR contains the following:
- restructuring/fixing the ``schemes/experiments.json`` schema and addition of ``extra_args``to the ``instances`` stanza
- support of fileless instances( resolves #78), by introducing the ``extra_args`` key for the ``instances``stanza
- documentation for fieless instances and the ``extra_args`` key

Below are some more details for the first two points:

The ``extra_args`` of instances are accessible via the already existing ``@EXTRA_ARGS@`` variable, which only resolved to the ``extra_args`` of variants before. Now it resolves to the concatenation of both (possible more, because we can have more than one variant for an experiment)``extra_args`` (from the instance and the variants).

-----

The validation schema for instances in the ``experiments.yml`` file can now roughly be expressed as:

```
if 'generator' in instance:
	check syntax for generator instances
if 'extensions' in instance:
	check syntax of multiple extension instances
if 'files' in instance:
	check syntax of arbitrary file instances
if neither of the above cases:
	check syntax for local/remote
```

(Notice the ``if-if``-construct instead of an ``if-elif``-construct which is due to the fact that [jsonschema 7.0](https://json-schema.org/understanding-json-schema/reference/conditionals.html) does not currently support ``if-elif``constructs.)

----

If an entity fails a ``oneOf`` construct, simexpal will now print out the errors for each subschema, e.g,: 

the entity

```
instances:
  - repo: local
    items:
      - name: baz
        extra_args: ['some','extra_args']
      # 'name' key is missing and 'foo' is an invalid key
      - extra_args: ['some','extra_args']
        foo: bar
  - repo: locjal    # typo of local
    items:
      - instance1
```

produces the following output when calling a ``simex`` command:

<img width="922" alt="Screen Shot 2020-11-27 at 21 57 50" src="https://user-images.githubusercontent.com/50080918/100484183-a8b08f80-30fb-11eb-81f0-692e9f41989b.png">
