### PR TITLE
Remove download option for konect instances

### DIFF
--- a/docs/instances.rst
+++ b/docs/instances.rst
@@ -9,10 +9,9 @@ You might want to take a look at the following pages before exploring instances:
 
 On this page we describe how to specify instances in the ``experiments.yml`` file. You can
 list local instances that consist of one file or several files. More over simexpal can download
-remote instances from the `KONECT <http://konect.cc>`_ and `SNAP <https://snap.stanford.edu/data/>`_
-repository. It is also possible to assign instances to instance sets that enable a more efficient
-usage of the :ref:`command line interface <CommandLineReference>` and are useful when defining
-the run matrix.
+remote instances from the `SNAP <https://snap.stanford.edu/data/>`_ repository. It is also possible
+to assign instances to instance sets that enable a more efficient usage of the
+:ref:`command line interface <CommandLineReference>` and are useful when defining the run matrix.
 
 Instance Directory
 ------------------
@@ -56,8 +55,14 @@ An example of how to list a local set of instances is:
 Remote Instances
 ----------------
 
-It is possible to let simexpal download instances from the `KONECT <http://konect.cc>`_
-and `SNAP <https://snap.stanford.edu/data/>`_ repository.
+It is possible to let simexpal download instances from the `SNAP <https://snap.stanford.edu/data/>`_
+repository.
+
+.. note::
+    1st December 2020: It is no longer possible to automatically download `KONECT <http://konect.cc>`_
+    instances as the website is no longer publicly available. It is still possible to list them and
+    execute supported actions, e.g, transforming the instances to edgelist format via
+    ``simex instances run-transform --transform='to_edgelist'`` if you already have them saved locally.
 
 To list instances from the SNAP repository, set the value of ``repo`` to ``snap`` and put
 the file names without the ``.txt.gz`` extension in the ``items`` list.

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -228,15 +228,14 @@ Instances can be checked with:
 
 Unavailable instances will be shown in red, otherwise they will be shown in green.
 If instances are taken from a public repository, they can be downloaded automatically.
-We configured the YAML file below to use instances from `Konect <http://konect.cc/networks/>`_
-and `SNAP <https://snap.stanford.edu/data/>`_.
+We configured the YAML file below to use instances from `SNAP <https://snap.stanford.edu/data/>`_.
 
 .. literalinclude:: ../examples/download_instances/experiments.yml
    :linenos:
    :language: yaml
    :caption: experiments.yml with instances from public repositories.
 
-All the listed instances can be downloaded within the "./graphs" directory with:
+All the listed instances can be downloaded within the ``./graphs`` directory with:
 
 .. code-block:: bash
 

--- a/examples/download_instances/experiments.yml
+++ b/examples/download_instances/experiments.yml
@@ -1,9 +1,4 @@
 instances:
-  - repo: konect
-    items:
-      - 'dolphins'
-      - 'iceland'
-      - 'advogato'
   - repo: snap
     items:
       - 'facebook_combined'

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -16,6 +16,8 @@ DEFAULT_DEV_BUILD_NAME = '_dev'
 EXPERIMENTS_LIST_THRESHOLD = 30
 TIMEOUT_GRACE_PERIOD = 30
 
+DID_WARN_KONECT = False
+
 did_warn_libyaml = False
 YmlLoader = yaml.SafeLoader
 try:
@@ -656,17 +658,24 @@ class Instance:
 		return True
 
 	def install(self):
+		global DID_WARN_KONECT
+
 		if self.check_available() or self.is_fileless:
 			return
 
 		util.try_mkdir(self._cfg.instance_dir())
 
-		if 'repo' in self._inst_yml:
-			if self._inst_yml['repo'] == 'local':
-				return
-
 		partial_path = os.path.join(self._cfg.instance_dir(), self.unique_filename)
 		if 'repo' in self._inst_yml:
+
+			if self._inst_yml['repo'] == 'local':
+				return
+			elif self._inst_yml['repo'] == 'konect':
+				if not DID_WARN_KONECT:
+					print("Downloading instances from konect is no longer possible.")
+					DID_WARN_KONECT = True
+				return
+
 			print("Downloading instance '{}' from {} repository".format(self.unique_filename,
 					self._inst_yml['repo']))
 

--- a/simexpal/instances.py
+++ b/simexpal/instances.py
@@ -52,7 +52,7 @@ def download_instance(inst_yml, instances_dir, filename, partial_path, ext):
 		zip_file = zipfile.ZipFile(download_path + compression, 'r')
 		# TODO finish
 	else:
-		DownloadException('Unknown repository: ' + repo)
+		raise DownloadException('Unknown repository: ' + repo)
 
 	os.unlink(download_path)
 	os.rename(tmp_path, partial_path + ext)

--- a/simexpal/instances.py
+++ b/simexpal/instances.py
@@ -11,10 +11,6 @@ class DownloadException(Exception):
 	pass
 
 repos = {
-	'konect': {
-		'url': 'http://konect.cc/files/download.tsv.',
-		'file_fmt': '.tar.bz2',
-	},
 	'snap': {
 			'url': 'https://snap.stanford.edu/data/',
 			'file_fmt': '.txt.gz'
@@ -48,14 +44,7 @@ def download_instance(inst_yml, instances_dir, filename, partial_path, ext):
 
 	tmp_path = os.path.join(instances_dir, filename + '.tmp')
 	compression = fmt.split('.')[-1]
-	if repo == 'konect':
-		tar = tarfile.open(download_path, 'r:' + compression)
-		member_name = next(elem for elem in tar.getnames() if 'out.' in elem)
-
-		with tar.extractfile(member_name) as reader:
-			with open(tmp_path, 'wb') as f:
-				extract(reader, f)
-	elif repo == 'snap':
+	if repo == 'snap':
 		with gzip.open(download_path, 'rb') as reader:
 			with open(tmp_path, 'wb') as f:
 				extract(reader, f)


### PR DESCRIPTION
Resolves #85.

One thing that we should maybe reconsider is the removal of the konect case in ``convert_to_edgelist()`` located in the ``instances.py``. Users might have already downloaded konect instances. 

Alternatively, we could only remove the option of downloading konect instances and leave the rest. In this case users can still use ``simex instances run-transform`` manually on the instances.