### PR TITLE
Support VCS-less builds

### DIFF
--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -14,11 +14,14 @@ only Git is supported) and build them automatically. To achieve this, we need to
 
 On this page we will explain the ``builds`` key and mainly use the
 `C++ example <https://github.com/hu-macsy/simexpal/tree/master/examples/sorting_cpp>`_ from the
-:ref:`QuickStart` guide in order to do so. For example, we will explain how to specify a Git repository, enable
-the automated build support and the directories involved in the build process. Furthermore we will present
-additional options such as pulling Git submodules and setting additional environment variables for the build process.
+:ref:`QuickStart` guide in order to do so. For example, we will explain how to specify a Git repository or
+a local build that does not come from a VCS, enable the automated build support and the directories involved
+in the build process. Furthermore we will present additional options such as pulling Git submodules and setting
+additional environment variables for the build process.
 
 You can find information regarding the ``revisions`` key on the :ref:`Revisions` page.
+
+.. _SpecifyingGitRepository:
 
 Specifying a Git Repository
 ---------------------------
@@ -59,6 +62,19 @@ key to ``true`` in order for simexpal to pull the respective files.
         recursive-clone: true
 
 If ``recursive-clone`` is not set, it will default to ``false``.
+
+Specifying Builds Without Version Control
+-----------------------------------------
+
+Specifying builds without version control works similar to :ref:`SpecifyingGitRepository`. The differences are
+
+- we omit the ``git`` key *and*
+- store the local build files in ``./develop/<build_name>@<revision_name>``.
+
+**As of now local builds are only supported for** :ref:`DevRevisions` **as we can not guarantee reproducibility
+without some kind of identifier, e.g, a commit hash.**
+
+All the options below also apply for local builds (we just need to omit the ``git`` key, where applicable).
 
 Automated Builds
 ----------------
@@ -234,16 +250,14 @@ current build. In this way we make sure that simexpal builds the required builds
 
    builds:
      - name: build1
-       git: '<link_to_git_repo>'
+       ...
        requires:
          - build2
          - build3
        ...
      - name: build2
-       git: '<link_to_git_repo>'
        ...
      - name: build3
-       git: '<link_to_git_repo>'
        ...
 
 .. _BuildDirectories:
@@ -257,7 +271,7 @@ the following subsections we will cover the directories for :ref:`normal revisio
 
 .. _BuildDirectoriesNormalBuilds:
 
-Build Directories for normal Builds
+Build Directories for Normal Builds
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 A :ref:`normal revision<NormalRevisions>` in simexpal uses the ``/builds`` directory, which contains the four
 subdirectories
@@ -315,7 +329,7 @@ simexpal files have the suffix ``.simexpal``.
    ├── experiments.yml
    └── quicksort.cpp
 
-Build Directories for develop Builds
+Build Directories for Develop Builds
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A :ref:`develop revision<DevRevisions>` in simexpal uses the ``/dev-builds`` directory, which contains the two
@@ -330,7 +344,8 @@ and the ``/develop`` directory, which contains the
 
 during the build process:
 
-The functions of the respective directories are as :ref:`before<BuildDirectoriesNormalBuilds>`.
+The functions of the respective directories are as :ref:`before<BuildDirectoriesNormalBuilds>` (for local builds
+the clone directory contains the local program files).
 
 Below you can find the shortened directory structure of our
 `C++ example <https://github.com/hu-macsy/simexpal/tree/master/examples/sorting_cpp>`_ example

--- a/docs/revisions.rst
+++ b/docs/revisions.rst
@@ -58,8 +58,8 @@ Develop Revisions
 Specifying develop revisions works similarly to specifying :ref:`normal revisions<NormalRevisions>`. The differences
 are:
 
-- we add another key ``develop`` and set its value to ``true``
-- we leave the values of the ``build_version`` dict as empty string ``''``
+- we add another key ``develop`` and set its value to ``true`` *and*
+- we leave the values of the ``build_version`` dict as empty string ``''``.
 
 Values specified in the ``build_version`` dict will be ignored for develop revisions and simexpal will clone the
 latest project files.

--- a/scripts/simex
+++ b/scripts/simex
@@ -212,15 +212,15 @@ def select_phases_from_cli(args):
 
 	if args.recheckout:
 		if not args.f:
-			print("This would delete the local git repository for the build and reclone it. Confirm this action"
-					" by using the '-f' flag.")
+			print("This would delete the local git repository for the build and reclone it (does not apply to"
+					" VCS-less dev-builds). Confirm this action by using the '-f' flag.")
 			return []
 		else:
 			return subsequent_phases(simexpal.build.Phase.CHECKOUT)
 	elif args.checkout:
 		if not args.f:
-			print("This would delete the local git repository for the build and reclone it. Confirm this action"
-					" by using the '-f' flag.")
+			print("This would delete the local git repository for the build and reclone it (does not apply to"
+					" VCS-less dev-builds). Confirm this action by using the '-f' flag.")
 			return []
 		else:
 			return [simexpal.build.Phase.CHECKOUT]

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -779,7 +779,7 @@ class BuildInfo:
 
 	@property
 	def git_repo(self):
-		return self._build_yml.get('git', '')
+		return self._build_yml.get('git', None)
 
 	@property
 	def recursive_clone(self):

--- a/simexpal/build.py
+++ b/simexpal/build.py
@@ -67,11 +67,11 @@ class Phase(IntEnum):
 
 def make_build_in_order(cfg, build, wanted_builds, wanted_phases):
 	if not build.revision.is_dev_build:
-		util.try_mkdir('builds/')
+		util.try_mkdir(cfg.basedir + '/builds/')
 		checkout_dir = build.clone_dir
 	else:
-		util.try_mkdir('develop/')
-		util.try_mkdir('dev-builds/')
+		util.try_mkdir(cfg.basedir + '/develop/')
+		util.try_mkdir(cfg.basedir + '/dev-builds/')
 		checkout_dir = build.source_dir
 
 	def num_allocated_cpus():

--- a/simexpal/schemes/experiments.json
+++ b/simexpal/schemes/experiments.json
@@ -44,7 +44,7 @@
 			"type": "array",
 			"items": {
 				"type": "object",
-				"required": ["name", "git"],
+				"required": ["name"],
 				"properties": {
 					"name": {"type": "string"},
 					"git": {"type":  "string"},

--- a/tests/builds/experiments_ymls/vcs_less/develop/vcs-less@main/script.py
+++ b/tests/builds/experiments_ymls/vcs_less/develop/vcs-less@main/script.py
@@ -1,0 +1,2 @@
+
+print("Hello World!")

--- a/tests/builds/experiments_ymls/vcs_less/experiments.yml
+++ b/tests/builds/experiments_ymls/vcs_less/experiments.yml
@@ -1,0 +1,25 @@
+# This file contains a VCS-less develop build.
+builds:
+  - name: vcs-less
+    regenerate:
+      - args:
+          - 'touch'
+          - 'regenerated'
+    configure:
+      - args:
+          - 'touch'
+          - 'configured'
+    compile:
+      - args:
+          - 'touch'
+          - 'compiled'
+    install:
+      - args:
+          - 'touch'
+          - 'installed'
+
+revisions:
+  - name: main
+    develop: true
+    build_version:
+      'vcs-less': ''

--- a/tests/builds/test_builds.py
+++ b/tests/builds/test_builds.py
@@ -1,0 +1,33 @@
+
+import os
+
+from simexpal import base
+from simexpal import build
+
+file_dir = os.path.abspath(os.path.dirname(__file__))
+
+def test_simex_d_vcs_less():
+    cfg = base.config_for_dir(file_dir + '/experiments_ymls/vcs_less/')
+
+    revision = cfg.get_revision('main')
+    vcs_less_build = cfg.get_build('vcs-less', revision)
+
+    build.make_builds(cfg, revision, [vcs_less_build.info], ['vcs-less'], [build.Phase.INSTALL])
+
+    def check_files_in_dir(files, dir):
+        for file_name in files:
+            assert os.path.isfile(dir + file_name)
+
+    source_dir_files = ['/regenerated',
+                        '/regenerated.simexpal']
+    check_files_in_dir(source_dir_files, vcs_less_build.source_dir)
+
+    compile_dir_files = ['/configured',
+                         '/configured.simexpal',
+                         '/compiled',
+                         '/compiled.simexpal',
+                         '/installed']
+    check_files_in_dir(compile_dir_files, vcs_less_build.compile_dir)
+
+    prefix_dir_files = ['/installed.simexpal']
+    check_files_in_dir(prefix_dir_files, vcs_less_build.prefix_dir)


### PR DESCRIPTION
This PR resolves #87.

The formatting of the changes in ``build.py`` are formatted weirdly. I only encapsulated the current checkout process by ``if build.info.git_repo is not None:`` to check that it is a git-build and ``print("simexpal: Skipping checkout-phase for git-less dev-build {}".format(build.name))`` otherwise. After the checkout process I make sure that the ``/develop/<build_name>@<revision_name>`` directory exists in case the build is git-less.