### PR TITLE
Download instances from a URL and Git repo, fix broken 'simex i install --overwrite' command

### DIFF
--- a/docs/at_variables_reference.rst
+++ b/docs/at_variables_reference.rst
@@ -21,6 +21,7 @@ Below, we list all @-variables and where they can be used.
 - ``@INSTANCE@``: path of a :ref:`local <LocalInstances>`/:ref:`remote <RemoteInstances>` instance, i.e. ``/instance_directory/<instance_name>``
 - ``@INSTANCE:<ext>@``: path of a :ref:`MultipleExtensions` instance with extension ``<ext>``, i.e. ``/instance_directory/<instance_name>.<ext>``
 - ``@INSTANCE:<idx>@``: path of an :ref:`ArbitraryInputFiles` instance with index ``<idx>`` in the ``files`` key, i.e. ``/instance_directory/files[<idx>]``
+- ``@INSTANCE_FILENAME@``: filename of the instance
 - ``@OUTPUT@``: path to the output file of an experiment
 - ``@OUTPUT:<ext>@``: path to the output file with extension ``<ext>`` of an experiment
 - ``@OUTPUT_SUBDIR@``: output subdirectory of the experiment where the output and status files are stored, i.e. ``/path_to_experiments_yml/output/``
@@ -113,3 +114,14 @@ workdir
 ^^^^^^^
 
 Same as for the :ref:`AtVariablesExperimentsArgs` key `without` the ``@EXTRA_ARGS@`` variable.
+
+
+Instances
+---------
+
+url
+^^^
+
+The following @-variables can be used in the ``url`` key:
+
+- ``@INSTANCE_FILENAME@``

--- a/docs/instances.rst
+++ b/docs/instances.rst
@@ -6,6 +6,7 @@ Instances
 You might want to take a look at the following pages before exploring instances:
 
 - :ref:`QuickStart`
+- :ref:`AtVariables`
 
 On this page we describe how to specify instances in the ``experiments.yml`` file. You can
 list local instances that consist of one file or several files. More over simexpal can download
@@ -55,14 +56,26 @@ An example of how to list a local set of instances is:
 Remote Instances
 ----------------
 
-It is possible to let simexpal download instances from the `SNAP <https://snap.stanford.edu/data/>`_
-repository.
+It is possible to let simexpal download instances from `SNAP <https://snap.stanford.edu/data/>`_,
+a URL and a Git repository. In the sections below, we will see how to list the different
+kinds of remote instances in the ``experiments.yml``.
+
+After listing the instances we need to use
+
+.. code-block:: bash
+
+   $ simex instances install
+
+to download the instances into the instance directory.
 
 .. note::
     1st December 2020: It is no longer possible to automatically download `KONECT <http://konect.cc>`_
     instances as the website is no longer publicly available. It is still possible to list them and
     execute supported actions, e.g, transforming the instances to edgelist format via
     ``simex instances run-transform --transform='to_edgelist'`` if you already have them saved locally.
+
+Instances From SNAP
+^^^^^^^^^^^^^^^^^^^
 
 To list instances from the SNAP repository, set the value of ``repo`` to ``snap`` and put
 the file names without the ``.txt.gz`` extension in the ``items`` list.
@@ -85,13 +98,81 @@ the internal names of the KONECT instances in the ``items`` list.
           - dolphins
           - ucidata-zachary
 
-After listing the instances use
+Instances From a URL
+^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: bash
+To list instances from a URL, we use the following keys:
 
-   $ simex instances install
+- ``method``: download method
+- ``url``: URL of the instance
 
-to download the instances into the instance directory.
+We set the value of the ``method`` key to ``'url'`` and specify the URL of the instance in the
+``url`` key.
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to list instances from a URL in the experiments.yml file.
+
+   instdir: "<path_to_instance_directory>"
+   instances:
+     - method: url
+       url: 'https://raw.githubusercontent.com/hu-macsy/simexpal/master/simexpal/schemes/@INSTANCE_FILENAME@'
+       items:
+         - 'experiments.json'
+         - 'launchers.json'
+
+The :ref:`@-variable <AtVariables>` ``@INSTANCE_FILENAME@`` in the URL (from the example above) resolves to
+the elements in the ``items`` key. Thus, we have listed the two instances ``experiments.json`` and
+``launchers.json``, which come from
+`<https://raw.githubusercontent.com/hu-macsy/simexpal/master/simexpal/schemes/experiments.json>`_ and
+`<https://raw.githubusercontent.com/hu-macsy/simexpal/master/simexpal/schemes/launchers.json>`_ respectively.
+
+Instances From Git
+^^^^^^^^^^^^^^^^^^
+
+To list instances from a Git repository, we use the following keys:
+
+- ``method``: download method
+- ``git``: link to the Git repository
+- ``repo_name``: name of the directory to clone into
+- ``commit``: SHA-1 hash
+- ``git_subdir``: subdirectory of the instance in the Git repository
+
+
+We set the value of the ``method`` key to ``'git'`` and specify the Git URL of the instance in the
+``git`` key. The ``repo_name`` states the local directory name of the Git repository. When installing
+the instance, the Git repository will be stored in ``<instance_dir>/<repo_name>``. The ``commit`` value
+specifies the version of the instance given as SHA-1 hash. It is also possible to specify other revision
+parameters, e.g. ref names. For reproducibility reasons the former variant is recommended. If the instance
+is not located in the root directory of the Git repository, we will need to specify the subdirectory of
+the instance in ``git_subdir``.
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to list instances from a Git repository in the experiments.yml file.
+
+   instdir: "<path_to_instance_directory>"
+   instances:
+     - method: git
+       git: 'https://github.com/hu-macsy/simexpal'
+       repo_name: 'foo'
+       commit: 'master'
+       items:
+         - 'setup.py'
+         - 'pytest.ini'
+     - method: git
+       git: 'https://github.com/hu-macsy/simexpal'
+       repo_name: 'foo'
+       commit: 'd5e598f292b90cd7ef2e77d7a478ec52d42279df'
+       git_subdir: 'simexpal/schemes/'
+       items:
+         - 'experiments.json'
+         - 'launchers.json'
+
+In the example above we clone the simexpal repository into ``<instance_dir>/foo``. Then ``setup.py`` and
+``pytest.ini`` of the current ``master`` branch and ``simexpal/schemes/experiments.json`` and
+``simexpal/schemes/launchers.json`` of the specified commit ``d5e598f292b90cd7ef2e77d7a478ec52d42279df``
+will be downloaded into the instance directory.
 
 Multiple Input Files
 --------------------

--- a/scripts/simex
+++ b/scripts/simex
@@ -300,7 +300,7 @@ def do_instances_install(args):
 
 	for instance in cfg.all_instances():
 		if args.overwrite:
-			util.try_rmfile(os.path.join(cfg.instance_dir(), instance.shortname))
+			util.try_rmfile(os.path.join(cfg.instance_dir(), instance.unique_filename))
 		instance.install()
 
 instances_install_parser = instances_subcmds.add_parser('install')

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -659,6 +659,22 @@ class Instance:
 	def url(self):
 		return self._inst_yml.get('url', None)
 
+	@property
+	def git(self):
+		return self._inst_yml.get('git', None)
+
+	@property
+	def repo_name(self):
+		return self._inst_yml.get('repo_name', None)
+
+	@property
+	def commit(self):
+		return self._inst_yml.get('commit', None)
+
+	@property
+	def git_subdir(self):
+		return self._inst_yml.get('git_subdir', None)
+
 	def check_available(self):
 		for file in self.filenames:
 			if not os.path.isfile(os.path.join(self._cfg.instance_dir(), file)):

--- a/simexpal/instances.py
+++ b/simexpal/instances.py
@@ -4,7 +4,7 @@ import os
 import requests
 import zipfile
 
-from .util import try_mkdir
+from .util import try_mkdir, expand_at_params
 
 class DownloadException(Exception):
 	pass
@@ -21,40 +21,58 @@ repos = {
 }
 
 def download_instance(inst_yml, instances_dir, filename, partial_path, ext):
-	repo = inst_yml['repo']
+	shortname = os.path.splitext(filename)[0]
+	if 'repo' in inst_yml:
+		repo = inst_yml['repo']
 
-	try_mkdir(instances_dir)
+		try_mkdir(instances_dir)
 
-	# Download the instance from the repository.
-	prefix = ''
-	if 'repo-subdir' in inst_yml:
-		prefix = inst_yml['repo-subdir'] + '/'
-	fmt = repos[repo]['file_fmt']
-	url = repos[repo]['url'] + prefix + filename + fmt
+		# Download the instance from the repository.
+		prefix = ''
+		if 'repo-subdir' in inst_yml:
+			prefix = inst_yml['repo-subdir'] + '/'
+		fmt = repos[repo]['file_fmt']
+		url = repos[repo]['url'] + prefix + filename + fmt
 
-	download_path = os.path.join(instances_dir, filename + '.download')
-	request = requests.get(url)
-	with open(download_path, 'wb') as f:
-		f.write(request.content)
+		download_path = os.path.join(instances_dir, filename + '.download')
+		request = requests.get(url)
+		with open(download_path, 'wb') as f:
+			f.write(request.content)
 
-	# Decompress the instance.
-	def extract(reader, f):
-		f.write(reader.read())
+		# Decompress the instance.
+		def extract(reader, f):
+			f.write(reader.read())
 
-	tmp_path = os.path.join(instances_dir, filename + '.tmp')
-	compression = fmt.split('.')[-1]
-	if repo == 'snap':
-		with gzip.open(download_path, 'rb') as reader:
-			with open(tmp_path, 'wb') as f:
-				extract(reader, f)
-	elif repo == 'network_repository':
-		zip_file = zipfile.ZipFile(download_path + compression, 'r')
-		# TODO finish
+		tmp_path = os.path.join(instances_dir, filename + '.tmp')
+		compression = fmt.split('.')[-1]
+		if repo == 'snap':
+			with gzip.open(download_path, 'rb') as reader:
+				with open(tmp_path, 'wb') as f:
+					extract(reader, f)
+		elif repo == 'network_repository':
+			zip_file = zipfile.ZipFile(download_path + compression, 'r')
+			# TODO finish
+		else:
+			raise DownloadException('Unknown repository: ' + repo)
+
+		os.unlink(download_path)
+		os.rename(tmp_path, partial_path + ext)
+	elif 'method' in inst_yml:
+		method = inst_yml['method']
+		if method == 'url':
+			def substitute(p):
+				if p == 'INSTANCE_FILENAME':
+					return filename
+				raise RuntimeError("Unexpected parameter {}".format(p))
+
+			url = expand_at_params(inst_yml['url'], substitute)
+			request = requests.get(url)
+			with open(partial_path + ext, 'wb') as f:
+				f.write(request.content)
+		else:
+			raise RuntimeError(f"Unknown method for instance '{shortname}': {method}")
 	else:
-		raise DownloadException('Unknown repository: ' + repo)
-
-	os.unlink(download_path)
-	os.rename(tmp_path, partial_path + ext)
+		raise RuntimeError(f"Unknown download option for instance '{shortname}'")
 
 # Reformats the network to a SNAP/EdgeList format.
 def convert_to_edgelist(inst_yml, in_path, out_path):

--- a/simexpal/instances.py
+++ b/simexpal/instances.py
@@ -69,6 +69,23 @@ def download_instance(inst_yml, instances_dir, filename, partial_path, ext):
 			request = requests.get(url)
 			with open(partial_path + ext, 'wb') as f:
 				f.write(request.content)
+		elif method == 'git':
+			import subprocess
+
+			repo_dir = os.path.join(instances_dir, inst_yml['repo_name'])
+			if not os.path.isdir(repo_dir):
+				subprocess.check_call(['git', 'clone', inst_yml['git'], repo_dir, '--no-checkout'])
+
+			git_subdir = inst_yml.get('git_subdir', None)
+			if git_subdir is not None:
+				file_path = os.path.join(git_subdir, filename)
+			else:
+				file_path = filename
+
+			object_name = inst_yml['commit'] + ':' + file_path
+			output = subprocess.check_output(['git', 'show', object_name], cwd=repo_dir)
+			with open(os.path.join(instances_dir, filename + ext), 'wb') as f:
+				f.write(output)
 		else:
 			raise RuntimeError(f"Unknown method for instance '{shortname}': {method}")
 	else:

--- a/simexpal/schemes/experiments.json
+++ b/simexpal/schemes/experiments.json
@@ -83,6 +83,12 @@
 			"type": "array",
 			"items": {
 				"type": "object",
+				"properties": {
+					"method": {
+						"type": "string",
+						"enum": ["url"]
+					}
+				},
 				"allOf": [
 					{
 						"if": {
@@ -202,6 +208,55 @@
 					},
 					{
 						"if": {
+							"required": ["method"],
+							"properties": {
+								"method": {"type": "string"}
+							}
+						},
+						"then": {
+							"allOf": [
+								{
+									"if": {
+										"required": ["method"],
+										"properties": {
+											"method": {"const": "url"}
+										}
+									},
+									"then": {
+										"required": ["method", "url", "items"],
+										"properties": {
+											"method": {"const": "url"},
+											"url": {"type": "string"},
+											"set": {"$ref": "#/definitions/str_or_str_list"},
+											"postprocess": {"const": "to_edgelist"},
+											"items": {
+												"oneOf": [
+													{
+														"$ref": "#/definitions/str_list"
+													},
+													{
+														"type": "array",
+														"items": {
+															"type": "object",
+															"required": ["name"],
+															"properties": {
+																"name": {"type": "string"},
+																"extra_args": {"$ref": "#/definitions/str_list"}
+															},
+															"additionalProperties": false
+														}
+													}
+												]
+											}
+										},
+										"additionalProperties": false
+									}
+								}
+							]
+						}
+					},
+					{
+						"if": {
 							"not": {
 								"anyOf": [
 									{
@@ -229,6 +284,12 @@
 													}
 												}
 											}
+										}
+									},
+									{
+										"required": ["method"],
+										"properties": {
+											"method": {"type": "string"}
 										}
 									}
 								]

--- a/simexpal/schemes/experiments.json
+++ b/simexpal/schemes/experiments.json
@@ -86,7 +86,7 @@
 				"properties": {
 					"method": {
 						"type": "string",
-						"enum": ["url"]
+						"enum": ["url", "git"]
 					}
 				},
 				"allOf": [
@@ -227,6 +227,46 @@
 										"properties": {
 											"method": {"const": "url"},
 											"url": {"type": "string"},
+											"set": {"$ref": "#/definitions/str_or_str_list"},
+											"postprocess": {"const": "to_edgelist"},
+											"items": {
+												"oneOf": [
+													{
+														"$ref": "#/definitions/str_list"
+													},
+													{
+														"type": "array",
+														"items": {
+															"type": "object",
+															"required": ["name"],
+															"properties": {
+																"name": {"type": "string"},
+																"extra_args": {"$ref": "#/definitions/str_list"}
+															},
+															"additionalProperties": false
+														}
+													}
+												]
+											}
+										},
+										"additionalProperties": false
+									}
+								},
+								{
+									"if": {
+										"required": ["method"],
+										"properties": {
+											"method": {"const": "git"}
+										}
+									},
+									"then": {
+										"required": ["method", "git", "repo_name", "commit", "items"],
+										"properties": {
+											"method": {"const": "git"},
+											"git": {"type": "string"},
+											"repo_name": {"type": "string"},
+											"commit": {"type": "string"},
+											"git_subdir": {"type": "string"},
 											"set": {"$ref": "#/definitions/str_or_str_list"},
 											"postprocess": {"const": "to_edgelist"},
 											"items": {

--- a/tests/instances/experiments_ymls/git/experiments.yml
+++ b/tests/instances/experiments_ymls/git/experiments.yml
@@ -1,0 +1,18 @@
+# This file contains download instances from git with
+# a branch and a SHA-hash as commit identifier.
+instances:
+  - method: git
+    git: 'https://github.com/hu-macsy/simexpal'
+    repo_name: 'foo'
+    commit: 'master'
+    items:
+      - 'setup.py'
+      - 'pytest.ini'
+  - method: git
+    git: 'https://github.com/hu-macsy/simexpal'
+    repo_name: 'foo'
+    commit: 'd5e598f292b90cd7ef2e77d7a478ec52d42279df'
+    git_subdir: 'simexpal/schemes/'
+    items:
+      - 'experiments.json'
+      - 'launchers.json'

--- a/tests/instances/experiments_ymls/snap/experiments.yml
+++ b/tests/instances/experiments_ymls/snap/experiments.yml
@@ -1,0 +1,6 @@
+# This file contains download instances from the SNAP repository.
+instances:
+  - repo: snap
+    items:
+      - 'wiki-RfA'
+      - 'wiki-Vote'

--- a/tests/instances/experiments_ymls/url/experiments.yml
+++ b/tests/instances/experiments_ymls/url/experiments.yml
@@ -1,0 +1,7 @@
+# This file contains download instances from an URL.
+instances:
+  - method: url
+    url: 'https://raw.githubusercontent.com/hu-macsy/simexpal/master/simexpal/schemes/@INSTANCE_FILENAME@'
+    items:
+      - 'experiments.json'
+      - 'launchers.json'

--- a/tests/instances/test_installation.py
+++ b/tests/instances/test_installation.py
@@ -1,0 +1,20 @@
+
+import os
+import pytest
+from simexpal import base
+
+file_dir = os.path.abspath(os.path.dirname(__file__))
+
+yml_dirs = ['/experiments_ymls/snap/',
+            '/experiments_ymls/url/',
+            '/experiments_ymls/git/']
+
+@pytest.mark.parametrize('rel_yml_path', yml_dirs)
+def test_download(rel_yml_path):
+    cfg = base.config_for_dir(file_dir + rel_yml_path)
+
+    for instance in cfg.all_instances():
+        instance.install()
+
+        assert instance.check_available()
+        assert os.path.getsize(instance.fullpath) > 0


### PR DESCRIPTION
This PR contains the following:
- Support download of instances from a URL
- Support download of instances from a Git repository 
    - similar to #60 (differences below)
    - does not checkout the repository during the cloning process (``git clone <url> <directory> --no-checkout``)
    - not limited to one item
    - instances will have the same filenames as in the git repository
- Unit tests for both use cases
- Documentation for both features
- Fix broken ``simex i install --overwrite`` command
    - in cases where ``shortname != unique_filename`` the instance was not overwritten