### PR TITLE
QoL improvements for QueueLauncher

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Welcome to simexpal's documentation!
    Experiments <experiments>
    Variants <variants>
    Run Matrix <run_matrix>
+   Launcher <launcher>
    Command-line Reference <command_line_reference>
    Python API <python_api>
    Recipes <recipes>

--- a/docs/launcher.rst
+++ b/docs/launcher.rst
@@ -1,0 +1,178 @@
+.. _Launcher:
+
+Launcher
+=========
+
+On this page we describe the different launchers for experiments. It is possible to use the local
+machine or batch schedulers like `Slurm <https://slurm.schedmd.com/overview.html>`_ or
+`Oracle Grid Engine <https://docs.oracle.com/cd/E19680-01/html/821-1541/docinfo.html#scrolltoc>`_
+(formerly SGE) to run experiments. The launchers can be selected by adding further arguments to
+the ``simex experiments launch`` command or by setting up a ``launchers.yml`` file. The structure
+of this file will also be explained on this page.
+
+In the following sections, we consider the
+`sorting expample <https://github.com/hu-macsy/simexpal/tree/master/examples/sorting>`_ from the
+:ref:`QuickStart` guide.
+
+..
+    TODO: Add section on ForkLauncher, Slurm, SGE
+
+Queue Launcher
+--------------
+
+The queue launcher is mainly useful in scenarios where no sophisticated batch scheduler (e.g.
+`Slurm <https://slurm.schedmd.com/overview.html>`_) is available, especially when launching
+experiments on a remote machine over ``ssh``. In this case it does not require an active connection.
+As the name suggests, the queue launcher puts the jobs in a queue and executes them sequentially.
+It is possible to start a queue launcher as a daemon or interactively in a terminal. You can launch
+experiments and monitor/stop/kill the launcher.
+
+Starting the Launcher
+^^^^^^^^^^^^^^^^^^^^^
+
+As Daemon
+~~~~~~~~~
+
+To start the queue launcher as a daemon you need to have the
+`systemd <https://www.freedesktop.org/wiki/Software/systemd/>`_ service manager installed. Then, use
+``simex queue daemon`` to start the launcher:
+
+.. code-block:: bash
+
+    $ simex queue daemon
+    Running as unit run-rdc0128bd4cd343e393681898359e5c69.service. # systemd output
+
+Terminal
+~~~~~~~~
+
+You can start the queue launcher in a terminal so that it is possible to directly see internal
+states of the launcher. You will then work from another terminal window in order to send commands to
+the launcher. To start the launcher, use ``simex queue interactive``:
+
+.. code-block:: bash
+
+    $ simex queue interactive
+    Serving on /home/username/.extl.sock  # internal message of the queue launcher
+
+Troubleshooting
+~~~~~~~~~~~~~~~
+
+If the daemon was not closed properly via the ``stop`` or ``kill`` command, a UNIX socket remains on the
+file system. In this case you need to add the ``--force`` argument to the ``simex queue interactive`` or
+``simex queue daemon`` command to start the launcher. Alternatively, you can delete the socket manually.
+The default path for the socket is ``~/.extl.sock``.
+
+Launching Experiments
+^^^^^^^^^^^^^^^^^^^^^
+
+To launch experiments through the queue launcher we need to :ref:`set up a launchers.yml file <launchers_yml>`
+or add the ``--launch-through=queue`` argument to the ``simex experiments launch`` command:
+
+.. code-block:: bash
+
+    $ simex experiments launch --launch-through=queue
+    Launching run bubble-sort/uniform-n1000-s1[0] on local machine
+    Launching run bubble-sort/uniform-n1000-s2[0] on local machine
+    Launching run bubble-sort/uniform-n1000-s3[0] on local machine
+    Launching run insertion-sort/uniform-n1000-s1[0] on local machine
+    Launching run insertion-sort/uniform-n1000-s2[0] on local machine
+    Launching run insertion-sort/uniform-n1000-s3[0] on local machine
+
+Show the Status
+^^^^^^^^^^^^^^^
+
+It is possible to query the launcher for the current run, pending runs and the number of completed runs.
+To do that, you can use ``simex queue show``:
+
+.. code-block:: bash
+
+    $ simex queue show
+    Currently running:   bubble-sort/uniform-n1000-s3[0]
+    Pending runs:        insertion-sort/uniform-n1000-s1[0]
+                         insertion-sort/uniform-n1000-s2[0]
+                         insertion-sort/uniform-n1000-s3[0]
+    Completed runs:      2
+
+Terminate
+^^^^^^^^^
+
+The launcher can be terminated by using the ``stop`` or ``kill`` command. The differences of those
+commands are stated below.
+
+- ``simex queue stop``: terminate the launcher after finishing all pending jobs
+- ``simex queue kill``: terminate the launcher immediately
+
+.. _launchers_yml:
+
+"launchers.yml" File
+--------------------
+
+The ``launchers.yml`` file contains a list of launchers. By setting up a ``launchers.yml`` file we can
+omit additional arguments in the ``simex experiments launch`` command or select launchers, which are
+defined in it. In the following sections, we will see how to setup and use our ``launchers.yml``. First,
+we need to create the ``launchers.yml`` file in the ``~/.simexpal/`` folder:
+
+.. code-block:: bash
+
+    $ mkdir ~/.simexpal     # Create the ~/.simexpal/ folder if it does not exist already
+    $ cd ~/.simexpal        # Navigate into ~/.simexpal/
+    $ touch launchers.yml   # Create an empty launchers.yml file
+
+Launchers
+^^^^^^^^^
+
+To specify launchers in the ``launchers.yml`` file we need to set the
+
+- ``launchers``: list of dictionaries, which contain launchers
+
+key.
+
+.. _QueueLauncher:
+
+Queue Launcher
+~~~~~~~~~~~~~~
+
+To define a queue launcher we need to add a list entry to the ``launchers`` key, which contains a
+dictionary with the
+
+- ``name``: name of the launcher
+- ``default``: boolean (``true``/``false``) - whether this is the default launcher or not
+- ``scheduler``: type of the launcher
+
+key.
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to specify a queue launcher in the launchers.yml file.
+
+    launchers:
+        - name: local-queue
+          default: true
+          scheduler: queue
+
+In this way we created a queue launcher with the name ``local-queue``. We also set it to be the default
+launcher.
+
+Command Line Interface
+^^^^^^^^^^^^^^^^^^^^^^
+
+Default Launcher
+~~~~~~~~~~~~~~~~
+
+When setting ``default: true`` for a launcher, ``simex experiments launch`` will run experiments
+with this launcher.
+
+.. warning::
+    There can only be one launcher with ``default: true``. Having multiple launchers with ``default: true``
+    will lead to a ``RuntimeError``.
+
+Selecting the Launcher
+~~~~~~~~~~~~~~~~~~~~~~
+
+When launching experiments using ``simex experiments launch``, you can specify the ``--launcher`` option
+to select a certain launcher defined in the ``launchers.yml`` file. For example:
+
+Assume you have a ``launchers.yml`` file set up as in the :ref:`QueueLauncher` section, then
+``simex experiments launch --launcher local-queue`` will select the launcher named ``local-queue`` from
+the ``launchers.yml`` file to run experiments.
+

--- a/scripts/simex
+++ b/scripts/simex
@@ -816,11 +816,10 @@ queue_stop_parser = queue_subcmds.add_parser('stop')
 queue_stop_parser.set_defaults(cmd=do_queue_stop)
 
 def do_queue_interactive(args):
-	simexpal.queuesock.run_queue(args.sockfd, args.force)
+	simexpal.queuesock.run_queue(force=args.force)
 
 queue_interactive_parser = queue_subcmds.add_parser('interactive')
 queue_interactive_parser.set_defaults(cmd=do_queue_interactive)
-queue_interactive_parser.add_argument('--sockfd', type=int)
 queue_interactive_parser.add_argument('--force', action='store_true')
 
 # ---------------------------------------------------------------------------------------

--- a/scripts/simex
+++ b/scripts/simex
@@ -828,6 +828,25 @@ def do_queue_kill(args):
 queue_kill_parser = queue_subcmds.add_parser('kill')
 queue_kill_parser.set_defaults(cmd=do_queue_kill)
 
+def do_queue_show(args):
+	queue_info = simexpal.queuesock.show_queue()
+
+	print('{:20.20} {}'.format('Currently running:', queue_info['current_run']))
+
+	if len(queue_info['pending_runs']) == 0:
+		print('{:20.20} {}'.format('Pending runs:', None))
+	else:
+		for i, pending_run in enumerate(queue_info['pending_runs']):
+			if i == 0:
+				print('{:20.20} {}'.format('Pending runs:', pending_run))
+			else:
+				print('{:20.20} {}'.format('', pending_run))
+
+	print('{:20.20} {}'.format('Completed runs:', queue_info['num_completed_runs']))
+
+queue_status_parser = queue_subcmds.add_parser('show')
+queue_status_parser.set_defaults(cmd=do_queue_show)
+
 # ---------------------------------------------------------------------------------------
 # Internal commands. Not intended for CLI users.
 # ---------------------------------------------------------------------------------------

--- a/scripts/simex
+++ b/scripts/simex
@@ -785,10 +785,14 @@ archive_parser.set_defaults(cmd=do_archive)
 # Advanced commands.
 # ---------------------------------------------------------------------------------------
 
+def do_queue(args):
+
+	return do_queue_daemon(args)
+
 queue_parser = main_subcmds.add_parser('queue', help='Local batch queue for experiments',
 		aliases=['q'])
+queue_parser.set_defaults(cmd=do_queue)
 queue_subcmds = queue_parser.add_subparsers()
-queue_subcmds.required = True
 
 def do_queue_daemon(args):
 	import shutil

--- a/scripts/simex
+++ b/scripts/simex
@@ -786,6 +786,7 @@ archive_parser.set_defaults(cmd=do_archive)
 # ---------------------------------------------------------------------------------------
 
 def do_queue(args):
+	args.force = False
 
 	return do_queue_daemon(args)
 
@@ -801,13 +802,16 @@ def do_queue_daemon(args):
 	script = os.path.abspath(sys.argv[0])
 
 	if shutil.which('systemd-run'):
-		subprocess.check_call(['systemd-run', '--user',
-				script, 'internal-queuesock'])
+		cmd = ['systemd-run', '--user', script, 'internal-queuesock']
+		if args.force:
+			cmd.append('--force')
+		subprocess.check_call(cmd)
 	else:
 		raise RuntimeError('No supported service manager is available')
 
 queue_daemon_parser = queue_subcmds.add_parser('daemon')
 queue_daemon_parser.set_defaults(cmd=do_queue_daemon)
+queue_daemon_parser.add_argument('--force', action='store_true')
 
 def do_queue_stop(args):
 	simexpal.queuesock.stop_queue()
@@ -913,11 +917,12 @@ invoke_parser.add_argument('--repetition', type=int) # Legacy argument for SGE.
 invoke_parser.add_argument('specfile', type=str)
 
 def do_internal_queuesock(args):
-	simexpal.queuesock.run_queue(args.sockfd)
+	simexpal.queuesock.run_queue(args.sockfd, args.force)
 
 internal_queuesock_parser = main_subcmds.add_parser('internal-queuesock')
 internal_queuesock_parser.set_defaults(cmd=do_internal_queuesock)
 internal_queuesock_parser.add_argument('--sockfd', type=int)
+internal_queuesock_parser.add_argument('--force', action='store_true')
 
 # ---------------------------------------------------------------------------------------
 

--- a/scripts/simex
+++ b/scripts/simex
@@ -822,6 +822,12 @@ queue_interactive_parser = queue_subcmds.add_parser('interactive')
 queue_interactive_parser.set_defaults(cmd=do_queue_interactive)
 queue_interactive_parser.add_argument('--force', action='store_true')
 
+def do_queue_kill(args):
+	simexpal.queuesock.kill_queue()
+
+queue_kill_parser = queue_subcmds.add_parser('kill')
+queue_kill_parser.set_defaults(cmd=do_queue_kill)
+
 # ---------------------------------------------------------------------------------------
 # Internal commands. Not intended for CLI users.
 # ---------------------------------------------------------------------------------------

--- a/scripts/simex
+++ b/scripts/simex
@@ -6,6 +6,7 @@
 import argparse
 import os
 import argcomplete
+import errno
 import re
 import sys
 
@@ -814,39 +815,71 @@ queue_daemon_parser.set_defaults(cmd=do_queue_daemon)
 queue_daemon_parser.add_argument('--force', action='store_true')
 
 def do_queue_stop(args):
-	simexpal.queuesock.stop_queue()
+	try:
+		simexpal.queuesock.stop_queue()
+	except FileNotFoundError:
+		print("There is currently no queue daemon running.")
+	except ConnectionRefusedError:
+		print("There is currently a queue daemon running that did not terminate properly. Use "
+			"'simex queue interactive --force' or 'simex q daemon --force' to forcefully launch a new daemon. "
+			"Alternatively you can delete the socket '{}' manually and start a new daemon.".format(
+			simexpal.base.DEFAULT_SOCKETPATH))
+
 
 queue_stop_parser = queue_subcmds.add_parser('stop')
 queue_stop_parser.set_defaults(cmd=do_queue_stop)
 
 def do_queue_interactive(args):
-	simexpal.queuesock.run_queue(force=args.force)
+	try:
+		simexpal.queuesock.run_queue(force=args.force)
+	except OSError as e:
+		if e.errno == errno.EADDRINUSE:
+			print("There is currently a queue daemon running or the daemon did not terminate properly. "
+				"Use 'simex queue interactive --force' to forcefully launch a new daemon.")
+		else:
+			raise e
 
 queue_interactive_parser = queue_subcmds.add_parser('interactive')
 queue_interactive_parser.set_defaults(cmd=do_queue_interactive)
 queue_interactive_parser.add_argument('--force', action='store_true')
 
 def do_queue_kill(args):
-	simexpal.queuesock.kill_queue()
+	try:
+		simexpal.queuesock.kill_queue()
+	except FileNotFoundError:
+		print("There is currently no queue daemon running.")
+	except ConnectionRefusedError:
+		print("There is currently a queue daemon running that did not terminate properly. Use "
+			"'simex queue interactive --force' or 'simex q daemon --force' to forcefully launch a new daemon. "
+			"Alternatively you can delete the socket '{}' manually and start a new daemon.".format(
+			simexpal.base.DEFAULT_SOCKETPATH))
 
 queue_kill_parser = queue_subcmds.add_parser('kill')
 queue_kill_parser.set_defaults(cmd=do_queue_kill)
 
 def do_queue_show(args):
-	queue_info = simexpal.queuesock.show_queue()
+	try:
+		queue_info = simexpal.queuesock.show_queue()
 
-	print('{:20.20} {}'.format('Currently running:', queue_info['current_run']))
+		print('{:20.20} {}'.format('Currently running:', queue_info['current_run']))
 
-	if len(queue_info['pending_runs']) == 0:
-		print('{:20.20} {}'.format('Pending runs:', None))
-	else:
-		for i, pending_run in enumerate(queue_info['pending_runs']):
-			if i == 0:
-				print('{:20.20} {}'.format('Pending runs:', pending_run))
-			else:
-				print('{:20.20} {}'.format('', pending_run))
+		if len(queue_info['pending_runs']) == 0:
+			print('{:20.20} {}'.format('Pending runs:', None))
+		else:
+			for i, pending_run in enumerate(queue_info['pending_runs']):
+				if i == 0:
+					print('{:20.20} {}'.format('Pending runs:', pending_run))
+				else:
+					print('{:20.20} {}'.format('', pending_run))
 
-	print('{:20.20} {}'.format('Completed runs:', queue_info['num_completed_runs']))
+		print('{:20.20} {}'.format('Completed runs:', queue_info['num_completed_runs']))
+	except FileNotFoundError:
+		print("There is currently no queue daemon running.")
+	except ConnectionRefusedError:
+		print("There is currently a queue daemon running that did not terminate properly. Use "
+			"'simex queue interactive --force' or 'simex q daemon --force' to forcefully launch a new daemon. "
+			"Alternatively you can delete the socket '{}' manually and start a new daemon.".format(
+			simexpal.base.DEFAULT_SOCKETPATH))
 
 queue_status_parser = queue_subcmds.add_parser('show')
 queue_status_parser.set_defaults(cmd=do_queue_show)
@@ -917,7 +950,14 @@ invoke_parser.add_argument('--repetition', type=int) # Legacy argument for SGE.
 invoke_parser.add_argument('specfile', type=str)
 
 def do_internal_queuesock(args):
-	simexpal.queuesock.run_queue(args.sockfd, args.force)
+	try:
+		simexpal.queuesock.run_queue(args.sockfd, args.force)
+	except OSError as e:
+		if e.errno == errno.EADDRINUSE:
+			print("There is currently a queue daemon running or the daemon did not terminate properly. "
+				"Use 'simex queue interactive --force' to forcefully launch a new daemon.")
+		else:
+			raise e
 
 internal_queuesock_parser = main_subcmds.add_parser('internal-queuesock')
 internal_queuesock_parser.set_defaults(cmd=do_internal_queuesock)

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -15,6 +15,7 @@ from . import util
 DEFAULT_DEV_BUILD_NAME = '_dev'
 EXPERIMENTS_LIST_THRESHOLD = 30
 TIMEOUT_GRACE_PERIOD = 30
+DEFAULT_SOCKETPATH = os.path.expanduser('~/.extl.sock')
 
 DID_WARN_KONECT = False
 

--- a/simexpal/launch/queue.py
+++ b/simexpal/launch/queue.py
@@ -1,7 +1,9 @@
 
 import os
 import tempfile
+import sys
 
+from ..base import DEFAULT_SOCKETPATH
 from . import common
 from .. import queuesock
 from .. import util
@@ -10,6 +12,18 @@ class QueueLauncher(common.Launcher):
 	def submit(self, cfg, run):
 		util.try_mkdir(os.path.join(cfg.basedir, 'aux'))
 		util.try_mkdir(os.path.join(cfg.basedir, 'aux/_queue'))
+
+		try:
+			queuesock.show_queue()
+		except FileNotFoundError:
+			print("There is currently no queue daemon running. Please start a new daemon before launching experiments.")
+			sys.exit(1)
+		except ConnectionRefusedError:
+			print("There is currently a queue daemon running that did not terminate properly. Use "
+				"'simex queue interactive --force' or 'simex q daemon --force' to forcefully launch a new daemon. "
+				 "Alternatively you can delete the socket '{}' manually and start a new daemon.".format(
+				DEFAULT_SOCKETPATH))
+			sys.exit(1)
 
 		if not common.lock_run(run):
 			return

--- a/simexpal/queuesock.py
+++ b/simexpal/queuesock.py
@@ -97,17 +97,16 @@ class Queue:
 				if not len(requests) == 0:
 					request = requests.pop(0)
 
-					if request['action'] == 'launch':
-						specfile_path = request['specfile_path']
-						with open(specfile_path, 'r') as f:
-							manifest = util.read_yaml_file(f)['manifest']
+					specfile_path = request['specfile_path']
+					with open(specfile_path, 'r') as f:
+						manifest = util.read_yaml_file(f)['manifest']
 
-						cur_run = self.get_run_display_name(manifest)
-						print("Launching run {}".format(cur_run))
+					cur_run = self.get_run_display_name(manifest)
+					print("Launching run {}".format(cur_run))
 
-						script = os.path.abspath(sys.argv[0])
+					script = os.path.abspath(sys.argv[0])
 
-						cur_subproc = subprocess.Popen([script, 'internal-invoke', '--method=queue', specfile_path])
+					cur_subproc = subprocess.Popen([script, 'internal-invoke', '--method=queue', specfile_path])
 				elif self._should_stop:
 					self.close()
 					break

--- a/simexpal/queuesock.py
+++ b/simexpal/queuesock.py
@@ -54,6 +54,12 @@ class Queue:
 							requests.append(request)
 						elif request['action'] == 'stop':
 							self._should_stop = True
+						elif request['action'] == 'kill':
+							print("Terminating current subprocess")
+							if cur_subprocess is not None:
+								cur_subprocess.terminate()
+							self.close()
+							return
 						else:
 							print("Ignoring request with unknown action '{}': {}".format(request['action'], request))
 
@@ -80,10 +86,12 @@ class Queue:
 
 						cur_subprocess = subprocess.Popen([script, 'internal-invoke', '--method=queue', specfile_path])
 				elif self._should_stop:
-					print("Closing socket on {}".format(self.socket_path))
-					self.socket.close()
-					os.remove(self.socket_path)
+					self.close()
 					break
+	def close(self):
+		print("Closing socket on {}".format(self.socket_path))
+		self.socket.close()
+		os.remove(self.socket_path)
 
 class Connection:
 	def __init__(self, connection):
@@ -135,4 +143,9 @@ def sendrecv(m):
 def stop_queue():
 	sendrecv({
 		'action': 'stop'
+	})
+
+def kill_queue():
+	sendrecv({
+		'action': 'kill'
 	})

--- a/simexpal/queuesock.py
+++ b/simexpal/queuesock.py
@@ -5,6 +5,7 @@ import selectors
 import subprocess
 import sys
 
+from . import base
 from . import util
 
 
@@ -140,19 +141,17 @@ def run_queue(sockfd=None, force=False):
 	if sockfd is not None:
 		serve_sock = socket.socket(fileno=sockfd)
 	else:
-		sockpath = os.path.expanduser('~/.extlq.sock')
 		serve_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 		if force:
-			util.try_rmfile(sockpath)
-		serve_sock.bind(sockpath)
+			util.try_rmfile(base.DEFAULT_SOCKETPATH)
+		serve_sock.bind(base.DEFAULT_SOCKETPATH)
 
 	queue = Queue(serve_sock)
 	queue.run()
 
 def sendrecv(m):
-	sockpath = os.path.expanduser('~/.extlq.sock')
 	s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-	s.connect(sockpath)
+	s.connect(base.DEFAULT_SOCKETPATH)
 	s.send(util.yaml_to_string(m).encode())
 	s.shutdown(socket.SHUT_WR)
 

--- a/simexpal/queuesock.py
+++ b/simexpal/queuesock.py
@@ -120,7 +120,17 @@ def sendrecv(m):
 	s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 	s.connect(sockpath)
 	s.send(util.yaml_to_string(m).encode())
+	s.shutdown(socket.SHUT_WR)
+
+	recv_buffer = bytes()
+	while True:
+		data = s.recv(4096)
+		if not data:
+			break
+		recv_buffer += data
+
 	s.close()
+	return util.yaml_from_string(recv_buffer.decode())
 
 def stop_queue():
 	sendrecv({


### PR DESCRIPTION
This PR fixes #81 and contains the following:

- added ``simex queue show`` command that lists the current job, all pending jobs the number of completed jobs
-``simex queue stop`` stops the queue after all pending jobs have been finished
- added ``simex queue kill`` command to immediately kill the Queue Launcher
- Documentation on how to use the Queue Launcher
- some minor fixes

There was a bullet point

- simex queue status command that asks the daemon whether it is running and/or busy or not.

in the original issue. I chose not to implement an extra command for that, as the informationen already can be extracted from the ``simex queue show`` command.