### PR TITLE
Improve performance of no ops

### DIFF
--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -119,6 +119,9 @@ class Config:
 
 						yield Variant(self, axis_yml['axis'], variant_yml)
 
+		if 'instdir' not in self.yml:
+			self.yml['instdir'] = './instances'
+
 		for inst in sorted(construct_instances(), key=lambda inst: inst.shortname):
 			if inst.shortname in self._insts:
 				raise RuntimeError("The instance name '{}' is ambiguous".format(inst.shortname))
@@ -156,6 +159,11 @@ class Config:
 
 				if exp_yml['name'] in self._exp_infos:
 					raise RuntimeError("The experiment name '{}' is ambiguous".format(exp_yml['name']))
+
+				if exp_yml.get('output', None) == 'stdout':
+					msg = "Specifying the stdout path via 'output: stdout' is deprecated and will be removed in future " \
+							"versions. Use 'stdout: out' instead."
+					warnings.warn(msg, DeprecationWarning)
 				self._exp_infos[exp_yml['name']] = ExperimentInfo(self, exp_yml)
 
 		try:
@@ -1338,12 +1346,9 @@ class Run:
 			raise RuntimeError("The experiment '{}' with instance '{}' has not been started yet".format(
 				self.experiment.display_name, self.instance.shortname))
 
-def read_and_validate_setup(basedir='.', setup_file='experiments.yml'):
-	return util.validate_setup_file(os.path.join(basedir, setup_file))
-
 def config_for_dir(basedir=None):
 	if basedir is None:
 		basedir = '.'
-	yml = read_and_validate_setup(basedir=basedir)
+	yml = util.validate_setup_file(basedir, 'experiments.yml', 'experiments.json')
 	return Config(os.path.abspath(basedir), yml)
 

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -9,7 +9,6 @@ import sys
 import tempfile
 import warnings
 
-from . import instances
 from . import util
 
 DEFAULT_DEV_BUILD_NAME = '_dev'
@@ -684,6 +683,8 @@ class Instance:
 		return True
 
 	def install(self):
+		from . import instances
+
 		global DID_WARN_KONECT
 
 		if self.check_available() or self.is_fileless:
@@ -745,6 +746,9 @@ class Instance:
 
 	def run_transform(self, transform, out_path):
 		assert transform == 'to_edgelist'
+
+		from . import instances
+
 		instances.convert_to_edgelist(self._inst_yml,
 				self.fullpath, out_path + '.transf1')
 		stage = 1

--- a/simexpal/instances.py
+++ b/simexpal/instances.py
@@ -1,7 +1,6 @@
 
 import gzip
 import os
-import requests
 import zipfile
 
 from .util import try_mkdir, expand_at_params
@@ -21,6 +20,8 @@ repos = {
 }
 
 def download_instance(inst_yml, instances_dir, filename, partial_path, ext):
+	import requests
+
 	shortname = os.path.splitext(filename)[0]
 	if 'repo' in inst_yml:
 		repo = inst_yml['repo']

--- a/simexpal/util.py
+++ b/simexpal/util.py
@@ -78,7 +78,8 @@ def read_setup_file(setup_file):
 
 	with open(setup_file, 'r') as f:
 		setup_dict = yaml.load(f, Loader=YmlLoader)
-	return setup_dict
+		last_mod = os.fstat(f.fileno()).st_mtime
+	return setup_dict, last_mod
 
 def validate_setup_file(setup_file):
 	""" Reads, validates and sanitizes the setup file
@@ -114,12 +115,12 @@ def validate_setup_file(setup_file):
 
 	cur_file_path = os.path.abspath(os.path.dirname(__file__))
 
-	exp_yml_dict = read_setup_file(setup_file)
+	exp_yml_dict, _ = read_setup_file(setup_file)
 	schema_path = os.path.join(cur_file_path, "schemes", "experiments.json")
 	_validate_dict(exp_yml_dict, "experiments.yml", schema_path)
 
 	try:
-		launchers_yml_dict = read_setup_file(os.path.expanduser('~/.simexpal/launchers.yml'))
+		launchers_yml_dict, _ = read_setup_file(os.path.expanduser('~/.simexpal/launchers.yml'))
 		schema_path = os.path.join(cur_file_path, "schemes", "launchers.json")
 		_validate_dict(launchers_yml_dict, "launchers.yml", schema_path)
 	except FileNotFoundError:

--- a/simexpal/util.py
+++ b/simexpal/util.py
@@ -110,19 +110,26 @@ def validate_setup_file(basedir, setup_file, setup_file_schema):
 							print("\nValidation errors in subschema [{}]:".format(cur_schema_index))
 						print(sub_error.message)
 					print()
-			sys.exit(1)
+			return False
+		return True
 
 	cur_file_path = os.path.abspath(os.path.dirname(__file__))
 
 	setup_file_path = os.path.join(basedir, setup_file)
 	setup_file_dict, _ = read_setup_file(setup_file_path)
 	setup_file_schema_path = os.path.join(cur_file_path, "schemes", setup_file_schema)
-	_validate_dict(setup_file_dict, setup_file, setup_file_schema_path)
+	setup_file_is_valid = _validate_dict(setup_file_dict, setup_file, setup_file_schema_path)
+
+	if not setup_file_is_valid:
+		sys.exit(1)
 
 	try:
 		launchers_yml_dict, _ = read_setup_file(os.path.expanduser('~/.simexpal/launchers.yml'))
 		launchers_yml_schema_path = os.path.join(cur_file_path, "schemes", "launchers.json")
-		_validate_dict(launchers_yml_dict, "launchers.yml", launchers_yml_schema_path)
+		launchers_yml_is_valid = _validate_dict(launchers_yml_dict, "launchers.yml", launchers_yml_schema_path)
+
+		if not launchers_yml_is_valid:
+			sys.exit(1)
 	except FileNotFoundError:
 		pass
 

--- a/tests/validation/test_experiments_yml.py
+++ b/tests/validation/test_experiments_yml.py
@@ -5,24 +5,33 @@ import pytest
 from simexpal import util
 
 file_dir = os.path.abspath(os.path.dirname(__file__))
-valid_experiments_ymls = ['/../../examples/sorting/experiments.yml',
-                          '/../../examples/sorting_cpp/experiments.yml',
-                          '/../../examples/download_instances/experiments.yml',
-                          '/experiments_ymls/valid/instances/extra_args.yml']
 
-invalid_experiments_ymls = ['/experiments_ymls/invalid/top_level-additional_property.yml',
-                            '/experiments_ymls/invalid/repo-invalid_value.yml']
+valid_experiments_ymls = ['../../examples/sorting/experiments.yml',
+                          '../../examples/sorting_cpp/experiments.yml',
+                          '../../examples/download_instances/experiments.yml',
+                          'experiments_ymls/valid/instances/extra_args.yml']
+
+invalid_experiments_ymls = ['experiments_ymls/invalid/top_level-additional_property.yml',
+                            'experiments_ymls/invalid/repo-invalid_value.yml']
+
 
 @pytest.mark.parametrize('rel_yml_path', valid_experiments_ymls)
 def test_valid_experiments_yml(rel_yml_path):
-    ret_val = util.validate_setup_file(file_dir + rel_yml_path)
+    rel_yml_dir = os.path.dirname(rel_yml_path)
+    yml_dir = os.path.join(file_dir, rel_yml_dir)
+    filename = os.path.basename(rel_yml_path)
+
+    ret_val = util.validate_setup_file(yml_dir, filename, 'experiments.json')
 
     assert isinstance(ret_val, dict)
-    assert 'instdir' in ret_val
 
 @pytest.mark.parametrize('rel_yml_path', invalid_experiments_ymls)
 def test_invalid_experiments_yml(rel_yml_path):
+    rel_yml_dir = os.path.dirname(rel_yml_path)
+    yml_dir = os.path.join(file_dir, rel_yml_dir)
+    filename = os.path.basename(rel_yml_path)
+
     with pytest.raises(SystemExit) as info:
-        util.validate_setup_file(file_dir + rel_yml_path)
+        util.validate_setup_file(yml_dir, filename, 'experiments.json')
 
     assert info.value.code == 1


### PR DESCRIPTION
This PR fixes #94 and contains the following:

- only import ``instances.py`` and ``requests`` when needed (speedup of ``~70ms`` on my machine, run time from ``~220ms`` to ``~150ms``)
- caching of validation results in ``validation.cache`` to avoid importing``jsonschema``:
    - if the cache entry matches the modification time stamp of the file, the file will not be validated (thus ``jsonschema`` will not be imported, additional speedup of ``~80ms``)
    - otherwise, the file will be validated (up to ``~5ms`` slowdown compared to validation without caching, caused by the additional operations involved in the caching process)
        - if the validation is succesful, the cache entry will be updated
        - otherwise, the cache entry will not be updated (thus, the file will be validated the next time ``simex`` is called)
 

