### PR TITLE
tighter Slurm integration, documentation, bug fix

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -74,6 +74,8 @@ It supports the following actions:
 :launch: launches all the non executed experiments.
 :print: displays all experimental output, including error outputs, on the command-line.
 :purge: deletes the experimental data. To confirm this action it needs the ``-f`` argument.
+:kill: terminates jobs submitted to or started by Slurm. To confirm this action it needs
+    the ``-f`` argument.
 
 All the above actions can be applied to a subset of experiments according to a `selection option`,
 which can be specified as an additional argument. Supported selection options are:

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -72,8 +72,8 @@ It supports the following actions:
    experiment will be grouped together. The ``--full`` option forces simexpal to display the
    full experiment name.
 :launch: launches all the non executed experiments.
-:purge: deletes the experimental data. To confirm this action it needs the ``-f`` argument.
 :print: displays all experimental output, including error outputs, on the command-line.
+:purge: deletes the experimental data. To confirm this action it needs the ``-f`` argument.
 
 All the above actions can be applied to a subset of experiments according to a `selection option`,
 which can be specified as an additional argument. Supported selection options are:
@@ -96,11 +96,11 @@ instances
 Checks and eventually downloads the instances for the experiments.
 It supports the following actions:
 
-:list: lists all the instances found in the experiments.yml file.
-   Available instances are shown in green, unavailable instances in red.
 :install: downloads all the missing instances if they are taken from a public repository.
    With the argument ``--overwrite`` it will also download the available instances and
    overwrite them.
+:list: lists all the instances found in the experiments.yml file.
+   Available instances are shown in green, unavailable instances in red.
 :process: caches information about instances.
 :run-transform: manually runs a transformation on instance files.
 

--- a/scripts/simex
+++ b/scripts/simex
@@ -701,7 +701,7 @@ def do_experiments_launch(args):
 
 		submit_to_launcher(cfg, launcher_runs)
 
-		cfg.writeback_status_cache()
+	cfg.writeback_status_cache()
 
 experiments_launch_parser = experiments_subcmds.add_parser('launch',
 		parents=[run_selection_parser])

--- a/scripts/simex
+++ b/scripts/simex
@@ -122,7 +122,7 @@ def cli_selects_run(args, run):
 	if args.failed:
 		if not run.get_status().is_negative:
 			return False
-	elif args.unfinished:
+	if args.unfinished:
 		status = run.get_status()
 		if not (status.is_neutral or status == Status.NOT_SUBMITTED):
 			return False

--- a/scripts/simex
+++ b/scripts/simex
@@ -8,6 +8,7 @@ import os
 import argcomplete
 import errno
 import re
+import subprocess
 import sys
 
 import simexpal as extl
@@ -768,6 +769,42 @@ def do_experiments_print_output(args):
 experiments_print_parser = experiments_subcmds.add_parser('print',
 		parents=[run_selection_parser])
 experiments_print_parser.set_defaults(cmd=do_experiments_print_output)
+
+def do_experiments_kill(args):
+	cfg = extl.base.config_for_dir()
+
+	wanted_slurm_jobids = []
+
+	for run in select_runs_from_cli(cfg, args):
+		# It only makes sense to kill Slurm jobs that were submitted or already started.
+		if run.get_status() in [Status.SUBMITTED, Status.STARTED]:
+			slurm_jobid = run.slurm_jobid
+			if slurm_jobid is not None:
+				if not args.f:
+					print("This would kill run {}/{}[{}] with Slurm jobid {}".format(
+						run.experiment.display_name, run.instance.shortname, run.repetition, run.slurm_jobid))
+				else:
+					print("Killing run {}/{}[{}] with Slurm jobid {}".format(
+						run.experiment.display_name, run.instance.shortname, run.repetition, run.slurm_jobid))
+				wanted_slurm_jobids.append(run.slurm_jobid)
+
+	if len(wanted_slurm_jobids) > 0:
+		if not args.f:
+			print("Use '-f' to confirm this action.")
+		else:
+			scancel_cmd = ['scancel']
+			scancel_cmd.extend(wanted_slurm_jobids)
+
+			subprocess.check_output(scancel_cmd)
+	else:
+		print("No Slurm jobs available")
+
+	cfg.writeback_status_cache()
+
+experiments_kill_parser = experiments_subcmds.add_parser('kill',
+		parents=[run_selection_parser])
+experiments_kill_parser.set_defaults(cmd=do_experiments_kill)
+experiments_kill_parser.add_argument('-f', action='store_true', help='execute kill')
 
 # ---------------------------------------------------------------------------------------
 

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -1230,6 +1230,18 @@ class Run:
 			internal_name += '[{}]'.format(self.repetition)
 		return internal_name
 
+	@property
+	def slurm_jobid(self):
+		try:
+			with open(self.aux_file_path('run'), 'r') as f:
+				data = yaml.load(f, Loader=YmlLoader)
+				if data is None:
+					# .run files before adding this property were completely empty
+					return None
+			return data.get('slurm_jobid', None)
+		except FileNotFoundError:
+			return None
+
 	# Contains auxiliary files that SHOULD NOT be necessary to determine the result of the run.
 	def aux_file_path(self, ext):
 		return os.path.join(self.experiment.aux_subdir,

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -1280,7 +1280,6 @@ class Run:
 			pass
 
 	def get_status(self):
-
 		internal_name = self.internal_name
 		if internal_name in self._cfg.status_cache_dict:
 			if self.instance.shortname in self._cfg.status_cache_dict[internal_name]:
@@ -1306,7 +1305,7 @@ class Run:
 							except FileNotFoundError:
 								pass
 
-				if last_mod == cache_entry["last_mod"]:
+				if last_mod == cache_entry.get('last_mod', None):
 
 					# Verify that the file with the same last modification time truly produced this
 					# cache entry by matching the cached status with the source it originated from.

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -1174,6 +1174,7 @@ class Status(IntEnum):
 	TIMEOUT = 5
 	KILLED = 6
 	FAILED = 7
+	BROKEN = 8
 
 	def __str__(self):
 		if self.value == Status.NOT_SUBMITTED:
@@ -1192,6 +1193,8 @@ class Status(IntEnum):
 			return 'killed'
 		if self.value == Status.FAILED:
 			return 'failed'
+		if self.value == Status.BROKEN:
+			return 'broken'
 
 	@property
 	def is_positive(self):
@@ -1203,7 +1206,7 @@ class Status(IntEnum):
 
 	@property
 	def is_negative(self):
-		return self.value in [Status.TIMEOUT, Status.KILLED, Status.FAILED]
+		return self.value in [Status.TIMEOUT, Status.KILLED, Status.FAILED, Status.BROKEN]
 
 class Run:
 	def __init__(self, cfg, experiment, instance, repetition):

--- a/simexpal/launch/common.py
+++ b/simexpal/launch/common.py
@@ -35,11 +35,11 @@ def lock_run(run):
 	os.close(lockfd)
 	return True
 
-def create_run_file(run):
+def create_run_file(run, yml_dict={}):
 
 	# Create the .run file. This signals that the run has been submitted.
-	with open(run.aux_file_path('run.tmp'), "w"):
-		pass
+	with open(run.aux_file_path('run.tmp'), 'w') as f:
+		yaml.dump(yml_dict, f)
 	os.rename(run.aux_file_path('run.tmp'), run.aux_file_path('run'))
 
 # Stores all information that is necessary to invoke a run.


### PR DESCRIPTION
This PR closes #92 and contains the following:

- query Slurm when encountering experiments submitted to or started by Slurm (details below)
- add ``Status.BROKEN`` for experiments that were launched through Slurm and have an unexpected Slurm status
- add ``simex experiments kill`` command (calls ``scancel`` internally)
      - ~``--submitted`` selects all experiments submitted to Slurm~
      - ~``--started`` selects all experiments started by Slurm~
      - uses the same run selection as in purge, launch etc.
      - by default: selects submitted and started experiments
- add documentation on Slurm launcher
- fix bug where the status cache would be written multiple times when using multiple launchers
- fix bug in run ``cli_selects_run()``, where it was not possible to select all runs that failed or were unfinished

Some details regarding the first bullet point:

When experiments are started by the Slurm launcher, the slurm jobid will be stored in the ``.run`` file. When simexpal determines ``submitted`` or ``started`` for a run that was started through Slurm and Slurm has not yet been queried (``Config.slurm_queried == False``), simexpal will query Slurm via ``squeue``. It will then parse the status of all listed jobs to avoid multiple ``squeue``commands and save them to ``Config.slurm_queried_jobs`` (key: Slurm jobid, value: ``simexpal.Status``) and set ``Config.slurm_queried = True``. Slurm statuses will be resolved as follows:
- Slurm status: ``PD`` -> simexpal: ``submitted``
- ``R``, ``CG`` -> ``started``
- any other (unexpected) status -> ``broken``

The parsed output can then be accesses via ~``Config.pop_slurm_queried_jobs(jobid)``~ ``Config.get_slurm_job_status(jobid)``. When a ``jobid`` that was not listed in ``squeue`` is provided, ``failed`` will be returned.