### PR TITLE
handle execve() errors gracefully

### DIFF
--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -1251,7 +1251,7 @@ class Run:
 				status = Status.TIMEOUT
 			elif status_dict['signal']:
 				status = Status.KILLED
-			elif status_dict['status'] > 0:
+			elif status_dict['status'] > 0 or status_dict.get('error', None):
 				status = Status.FAILED
 			else:
 				status = Status.FINISHED

--- a/tests/experiments/experiments_ymls/missing_program/experiments.yml
+++ b/tests/experiments/experiments_ymls/missing_program/experiments.yml
@@ -1,0 +1,17 @@
+# This file contains experiments with a non-existing program.
+instances:
+  - repo: local
+    items:
+        - name: foo
+          files: []
+          extra_args: []
+  - repo: local
+    items:
+        - name: bar
+          files: []
+          extra_args: []
+
+experiments:
+  - name: baz
+    args: ['./non_existing_file']
+    stdout: out

--- a/tests/experiments/test_status_file.py
+++ b/tests/experiments/test_status_file.py
@@ -1,0 +1,28 @@
+
+import os
+import pytest
+
+from simexpal import base
+from simexpal.launch.fork import ForkLauncher
+
+file_dir = os.path.abspath(os.path.dirname(__file__))
+
+yml_dirs = ['/experiments_ymls/missing_program']
+
+@pytest.mark.parametrize('rel_yml_path', yml_dirs)
+def test_experiments_missing_program(rel_yml_path):
+    cfg = base.config_for_dir(file_dir + rel_yml_path)
+
+    # Make sure that the needed instances are installed.
+    # The main test follows afterwards.
+    for instance in cfg.all_instances():
+        instance.install()
+
+        assert instance.check_available()
+
+    launcher = ForkLauncher()
+    for run in cfg.discover_all_runs():
+        launcher.submit(cfg, run)
+
+        assert run.get_status() == base.Status.FAILED
+        assert os.path.getsize(run.aux_file_path('stderr'))


### PR DESCRIPTION
This PR contains the following:
- fix #102 (the ``.status`` file will be created even if simexpal can not find the executable), this also fixed a bug where experiments were shown as ``started`` when the executable was not found
- added unit test for experiments with missing programs

In the ``launch/common.py`` I mainly wrapped

``` python

child = subprocess.Popen(cmd, cwd=cwd, env=environ,
				stdout=stdout, stderr=stderr)

```

in a ``try/except`` block and put the code below it in the ``else`` case.