### PR TITLE
Kill child processes when simexpal is terminated prematurely

### DIFF
--- a/docs/launcher.rst
+++ b/docs/launcher.rst
@@ -71,12 +71,12 @@ or add the ``--launch-through=queue`` argument to the ``simex experiments launch
 .. code-block:: bash
 
     $ simex experiments launch --launch-through=queue
-    Launching run bubble-sort/uniform-n1000-s1[0] on local machine
-    Launching run bubble-sort/uniform-n1000-s2[0] on local machine
-    Launching run bubble-sort/uniform-n1000-s3[0] on local machine
-    Launching run insertion-sort/uniform-n1000-s1[0] on local machine
-    Launching run insertion-sort/uniform-n1000-s2[0] on local machine
-    Launching run insertion-sort/uniform-n1000-s3[0] on local machine
+    Submitting run bubble-sort/uniform-n1000-s1[0] on to local queue launcher
+    Submitting run bubble-sort/uniform-n1000-s2[0] on to local queue launcher
+    Submitting run bubble-sort/uniform-n1000-s3[0] on to local queue launcher
+    Submitting run insertion-sort/uniform-n1000-s1[0] to local queue launcher
+    Submitting run insertion-sort/uniform-n1000-s2[0] to local queue launcher
+    Submitting run insertion-sort/uniform-n1000-s3[0] to local queue launcher
 
 Show the Status
 ^^^^^^^^^^^^^^^

--- a/simexpal/launch/queue.py
+++ b/simexpal/launch/queue.py
@@ -36,7 +36,7 @@ class QueueLauncher(common.Launcher):
 		with os.fdopen(specfd, 'w') as f:
 			util.write_yaml_file(f, specs)
 
-		print("Launching run {}/{}[{}] on local machine".format(
+		print("Submitting run {}/{}[{}] to local queue launcher".format(
 				run.experiment.display_name, run.instance.shortname, run.repetition))
 
 		queuesock.sendrecv({


### PR DESCRIPTION
This PR contains the following:

- fix #97

If ``SIGINT`` (CTRL + C) or ``SIGTERM`` is caught, kill running child processes before terminating. Note that we can not handle ``SIGKILL`` this way.