### PR TITLE
Add at-variables 'BASE_DIR' and 'INSTANCE_DIR'

### DIFF
--- a/docs/at_variables_reference.rst
+++ b/docs/at_variables_reference.rst
@@ -16,9 +16,11 @@ specify ``experiments.py @INSTANCE@`` as experiment arguments.
 
 Below, we list all @-variables and where they can be used.
 
+- ``@BASE_DIR@``: path of the directory containing the ``experiments.yml``
 - ``@COMPILE_DIR_FOR:<build_name>@``: :ref:`compilation directory <BuildDirectories>` of ``<build_name>`` in the same revision
 - ``@EXTRA_ARGS@``: extra arguments of all variants and the instance of an experiment
 - ``@INSTANCE@``: path of a :ref:`local <LocalInstances>`/:ref:`remote <RemoteInstances>` instance, i.e. ``/instance_directory/<instance_name>``
+- ``@INSTANCE_DIR@``: path of the :ref:`InstanceDirectory`
 - ``@INSTANCE:<ext>@``: path of a :ref:`MultipleExtensions` instance with extension ``<ext>``, i.e. ``/instance_directory/<instance_name>.<ext>``
 - ``@INSTANCE:<idx>@``: path of an :ref:`ArbitraryInputFiles` instance with index ``<idx>`` in the ``files`` key, i.e. ``/instance_directory/files[<idx>]``
 - ``@INSTANCE_FILENAME@``: filename of the instance
@@ -46,7 +48,9 @@ compile
 
 The following @-variables can be used in the ``compile`` key:
 
+- ``@BASE_DIR@``
 - ``@COMPILE_DIR_FOR:<build_name>@``
+- ``@INSTANCE_DIR@``
 - ``@PARALLELISM@``
 - ``@PREFIX_DIR_FOR:<build_name>@``
 - ``@SOURCE_DIR_FOR:<build_name>@``
@@ -98,9 +102,11 @@ args
 
 The following @-variables can be used in the ``args`` key:
 
+- ``@BASE_DIR@``
 - ``@COMPILE_DIR_FOR:<build_name>@`` (``<build>`` has to be in ``used_builds`` or be required by a build in it)
 - ``@EXTRA_ARGS@``
 - ``@INSTANCE@``
+- ``@INSTANCE_DIR@``
 - ``@INSTANCE:<ext>@``
 - ``@INSTANCE:<idx>@``
 - ``@OUTPUT@``

--- a/docs/experiments.rst
+++ b/docs/experiments.rst
@@ -177,11 +177,11 @@ the experiment as follows:
    experiments:
      - name: experiment1
        args: ['<name_of_executable_of_build1>', ...]
-       used_builds: [build1]
+       use_builds: [build1]
        ...
 
 In this way simexpal will check the :ref:`installation directory <BuildDirectories>` and the ``extra_paths``
-of the builds specified in ``used_builds`` for the executable. If a build
+of the builds specified in ``use_builds`` for the executable. If a build
 :ref:`requires other builds <DependentBuilds>` and they are properly specified in the ``requires`` key, then
 simexpal will also check the installation directories and ``extra_paths`` of those builds.
 

--- a/docs/instances.rst
+++ b/docs/instances.rst
@@ -15,6 +15,8 @@ and arbitrary URLs. It is also possible to assign instances to instance sets tha
 efficient usage of the :ref:`command line interface <CommandLineReference>` and are useful when
 defining the run matrix.
 
+.. _InstanceDirectory:
+
 Instance Directory
 ------------------
 

--- a/simexpal/build.py
+++ b/simexpal/build.py
@@ -122,6 +122,10 @@ def make_build_in_order(cfg, build, wanted_builds, wanted_phases):
 			return get_prefix_dir_for(var.split(':')[1])
 		elif var == 'PARALLELISM':
 			return str(get_concurrency())
+		elif var == 'BASE_DIR':
+			return cfg.basedir
+		elif var == 'INSTANCE_DIR':
+			return cfg.instance_dir()
 
 	# Build the environment.
 	def prepend_env(var, items):

--- a/simexpal/launch/common.py
+++ b/simexpal/launch/common.py
@@ -354,6 +354,10 @@ def invoke_run(manifest):
 			return manifest.get_prefix_dir_for(p.split(':')[1])
 		elif p == 'OUTPUT_SUBDIR':
 			return manifest.output_subdir
+		elif p == 'BASE_DIR':
+			return manifest.base_dir
+		elif p == 'INSTANCE_DIR':
+			return manifest.instance_dir
 		else:
 			return None
 
@@ -384,6 +388,10 @@ def invoke_run(manifest):
 			return manifest.get_compile_dir_for(p.split(':')[1])
 		elif p.startswith('PREFIX_DIR_FOR:'):
 			return manifest.get_prefix_dir_for(p.split(':')[1])
+		elif p == 'BASE_DIR':
+			return manifest.base_dir
+		elif p == 'INSTANCE_DIR':
+			return manifest.instance_dir
 		else:
 			return None
 	environ = os.environ.copy()


### PR DESCRIPTION
This PR contains the following:
- added the @-variables ``BASE_DIR`` and ``INSTANCE_DIR``

 Both at-variables can be used in in
- ``extra_paths`` in the ``builds`` key
- ``args``, ``environ`` and ``workdir`` in the ``regenerate``/``configure``/``compile``/``install`` key in ``builds``
- ``args`` and ``workdir`` in the ``experiments`` key