### PR TITLE
fix misleading status of queue launcher experiments and redirect queue launcher errors

### DIFF
--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -1296,6 +1296,16 @@ class Run:
 		except FileNotFoundError:
 			return None
 
+	def get_queue_jobid(self):
+		try:
+			with open(self.aux_file_path('run'), 'r') as f:
+				data = yaml.load(f, Loader=YmlLoader)
+				if data is None:
+					return None
+			return data.get('queue_jobid', None)
+		except FileNotFoundError:
+			return None
+
 	# Contains auxiliary files that SHOULD NOT be necessary to determine the result of the run.
 	def aux_file_path(self, ext):
 		return os.path.join(self.experiment.aux_subdir,

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -11,6 +11,7 @@ import tempfile
 import warnings
 
 from . import util
+from . import queuesock
 
 DEFAULT_DEV_BUILD_NAME = '_dev'
 EXPERIMENTS_LIST_THRESHOLD = 30
@@ -86,6 +87,9 @@ class Config:
 
 		self.slurm_queried = False
 		self.slurm_queried_jobs = {}
+
+		self.queue_queried = False
+		self.queue_queried_jobs = {}
 
 		self._insts = OrderedDict()
 		self._build_infos = OrderedDict()
@@ -460,6 +464,30 @@ class Config:
 		# This only holds for jobs that would receive the status
 		# 'submitted' or 'started' in Run._update_status_cache_dict().
 		return self.slurm_queried_jobs.get(jobid, Status.FAILED)
+
+	def query_queue(self):
+		if not self.queue_queried:
+			try:
+				self.queue_queried_jobs = queuesock.get_job_status_dict()
+			except FileNotFoundError:
+				#  There is no queue daemon running. The .extl.sock might have been deleted.
+				pass
+			except ConnectionRefusedError:
+				# A queue daemon that was not terminated properly is running.
+				pass
+
+			if len(self.queue_queried_jobs) > 0:
+				self.queue_queried = True
+
+	def get_queue_job_status(self, jobid):
+		# Returns 'failed' for jobs not listed in self.queue_queried_jobs
+		# This only holds for jobs that would receive the status
+		# 'submitted' or 'started' in Run._update_status_cache_dict()
+
+		# We receive queue_queried_jobs via communication with the queue socket, which can not
+		# communicate objects. Thus, we rely on using the int representation when communicating
+		# and need to cast it to its Status representation.
+		return Status(self.queue_queried_jobs.get(jobid, Status.FAILED))
 
 	def writeback_status_cache(self):
 		fd, path = tempfile.mkstemp(dir=self.basedir)
@@ -1339,23 +1367,29 @@ class Run:
 				status, last_mod = Status.STARTED, os.stat(self.output_file_path('out')).st_mtime
 
 				jobid = self.slurm_jobid
+				queue_jobid = self.get_queue_jobid()
 				if jobid is not None:
 					if not self._cfg.slurm_queried:
 						self._cfg.query_slurm()
 					status = self._cfg.get_slurm_job_status(jobid)
-
-					return status
+				elif queue_jobid is not None:
+					if not self._cfg.queue_queried:
+						self._cfg.query_queue()
+					status = self._cfg.get_queue_job_status(queue_jobid)
 
 			elif os.access(self.aux_file_path('run'), os.F_OK):
 				status, last_mod = Status.SUBMITTED, os.stat(self.aux_file_path('run')).st_mtime
 
 				jobid = self.slurm_jobid
+				queue_jobid = self.get_queue_jobid()
 				if jobid is not None:
 					if not self._cfg.slurm_queried:
 						self._cfg.query_slurm()
 					status = self._cfg.get_slurm_job_status(jobid)
-
-					return status
+				elif queue_jobid is not None:
+					if not self._cfg.queue_queried:
+						self._cfg.query_queue()
+					status = self._cfg.get_queue_job_status(queue_jobid)
 
 			elif os.access(self.aux_file_path('lock'), os.F_OK):
 				status, last_mod = Status.IN_SUBMISSION, os.stat(self.aux_file_path('lock')).st_mtime

--- a/simexpal/launch/queue.py
+++ b/simexpal/launch/queue.py
@@ -27,17 +27,19 @@ class QueueLauncher(common.Launcher):
 
 		if not common.lock_run(run):
 			return
-		common.create_run_file(run)
 
 		specfd, specfile = tempfile.mkstemp(prefix='', suffix='-spec.yml',
 											dir=os.path.join(cfg.basedir, 'aux/_queue'))
+
+		queue_jobid = util.extract_file_prefix_from_path(specfile, '-spec')
+		common.create_run_file(run, {'queue_jobid': queue_jobid})
 
 		specs = {'manifest': common.compile_manifest(run).yml}
 		with os.fdopen(specfd, 'w') as f:
 			util.write_yaml_file(f, specs)
 
-		print("Submitting run {}/{}[{}] to local queue launcher".format(
-				run.experiment.display_name, run.instance.shortname, run.repetition))
+		print("Submitting run {}/{}[{}] with queue jobid '{}' to local queue launcher".format(
+				run.experiment.display_name, run.instance.shortname, run.repetition, queue_jobid))
 
 		queuesock.sendrecv({
 			'action': 'launch',

--- a/simexpal/queuesock.py
+++ b/simexpal/queuesock.py
@@ -145,7 +145,8 @@ class Queue:
 
 					script = os.path.abspath(sys.argv[0])
 
-					cur_subproc = subprocess.Popen([script, 'internal-invoke', '--method=queue', specfile_path])
+					with open(os.path.join(manifest['config']['base_dir'], 'aux/_queue/' + queue_jobid + '.err'), 'w') as f:
+						cur_subproc = subprocess.Popen([script, 'internal-invoke', '--method=queue', specfile_path], stderr=f)
 				elif self._should_stop:
 					self.close()
 					break

--- a/simexpal/util.py
+++ b/simexpal/util.py
@@ -215,3 +215,17 @@ def read_file(path):
 	else:
 		with f:
 			return f.read()
+
+def extract_file_prefix_from_path(file_path, suffix=None):
+	"""
+
+	:param file_path: absolute file path
+	:param suffix: (optional) suffix which will be removed from the extensionless basename of the file
+	:return: prefix of file
+	"""
+
+	prefix = os.path.splitext(os.path.basename(file_path))[0]
+	if suffix is not None:
+		prefix = prefix.split(suffix)[0]
+
+	return prefix


### PR DESCRIPTION
This PR contains the following:
- fixes #108
    - store a ``queue_jobid`` in the ``.run`` file
    - add ``get_job_status_dict`` action to the queue launcher
    - query the queue launcher when determining the status of experiments launched by a queue launcher
- fixes #110 
    - redirect queue launcher errors to an ``/aux/_queue/<queue_jobid>.err`` file