### PR TITLE
Allow common 'extra_args' in url instances

### DIFF
--- a/simexpal/schemes/experiments.json
+++ b/simexpal/schemes/experiments.json
@@ -230,6 +230,7 @@
 										"properties": {
 											"method": {"const": "url"},
 											"url": {"type": "string"},
+											"extra_args": {"$ref": "#/definitions/str_list"},
 											"set": {"$ref": "#/definitions/str_or_str_list"},
 											"postprocess": {"const": "to_edgelist"},
 											"items": {


### PR DESCRIPTION
This PR fixes a bug where common ``extra_args`` were not allowed in url instances.