### PR TITLE
Automatic unpacking of URL instances

### DIFF
--- a/docs/experiments_reference.rst
+++ b/docs/experiments_reference.rst
@@ -41,6 +41,7 @@ used for specifying builds:
 - ``configure``: list of dictionaries containing configuration parameters
 - ``compile``: list of dictionaries containing compilation parameters
 - ``environ``: dictionary of (environment variable, value)-pairs
+- ``extra_paths``: list of extra paths, which simexpal should check when running an experiment that uses this build
 - ``git``: link to the Git repository
 - ``install``: list of dictionaries containing installation parameters
 - ``name``: (arbitrary) name of the build

--- a/docs/experiments_reference.rst
+++ b/docs/experiments_reference.rst
@@ -23,7 +23,9 @@ This entry is a list of instances that will be used for experiments. The followi
 used for specifying instances:
 
 - ``extensions``: list of extensions that the instance has
+- ``extra_args``:  list of extra arguments
 - ``files``: list of files the instance consists of
+- ``format``: archive format of the instance
 - ``items``: list of instances
 - ``name``: name of the instance (used when dealing with instances that consist of unrelated files)
 - ``repo``: source of instances

--- a/docs/instances.rst
+++ b/docs/instances.rst
@@ -77,6 +77,8 @@ to download the instances into the instance directory.
     execute supported actions, e.g, transforming the instances to edgelist format via
     ``simex instances run-transform --transform='to_edgelist'`` if you already have them saved locally.
 
+.. _SNAPInstances:
+
 Instances From SNAP
 ^^^^^^^^^^^^^^^^^^^
 
@@ -129,6 +131,47 @@ the elements in the ``items`` key. Thus, we have listed the two instances ``expe
 ``launchers.json``, which come from
 `<https://raw.githubusercontent.com/hu-macsy/simexpal/master/simexpal/schemes/experiments.json>`_ and
 `<https://raw.githubusercontent.com/hu-macsy/simexpal/master/simexpal/schemes/launchers.json>`_ respectively.
+
+Automatic Unpacking of Archives
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When dealing with instances from a URL, you might encounter archives. Simexpal can automatically unpack archives
+by specifying the archive format in the
+
+- ``format``: archive format of the instance
+
+key. Supported formats are formats supported by
+`shutil.unpack_archive() <https://docs.python.org/3.6/library/shutil.html#archiving-operations>`_ and also gzip'ed files,
+i.e.:
+
+- ``zip``: ZIP file (if the `zlib <https://docs.python.org/3.6/library/zlib.html#module-zlib>`_ module is available)
+- ``tar``: uncompressed tar file
+- ``gztar``: gzip’ed tar-file (if the `zlib <https://docs.python.org/3.6/library/zlib.html#module-zlib>`_ module is available)
+- ``bztar``: bzip2’ed tar-file (if the `bz2 <https://docs.python.org/3.6/library/bz2.html#module-bz2>`_ module is available)
+- ``xztar``: xz’ed tar-file (if the `lzma <https://docs.python.org/3.6/library/lzma.html#module-lzma>`_ module is available)
+- ``gz``: gzip'ed file.
+
+.. code-block:: YAML
+   :linenos:
+   :caption: How to automatically unpack instances from a URL in the experiments.yml file.
+
+   instdir: "<path_to_instance_directory>"
+   instances:
+     - method: url
+       url: https://snap.stanford.edu/data/@INSTANCE_FILENAME@.txt.gz
+       items:
+         - 'facebook_combined'
+         - 'wiki-Vote'
+       format: gz
+
+.. note::
+   This only serves as an example. Downloading instances from the `SNAP repository <https://snap.stanford.edu/data/>`_
+   should be done as mentioned :ref:`above <SNAPInstances>`.
+
+In the ``experiments.yml`` above we specified two instances ``facebook_combined`` and ``wiki-Vote``, which both come
+from the `SNAP repository <https://snap.stanford.edu/data/>`_. As visible in the URL, the instances are gzip archives.
+By setting ``format: gz`` we make sure that the appropriate unpacker is used.
+
 
 Instances From Git
 ^^^^^^^^^^^^^^^^^^

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -681,6 +681,10 @@ class Instance:
 		return self._inst_yml.get('commit', None)
 
 	@property
+	def format(self):
+		return self._inst_yml.get('format', None)
+
+	@property
 	def git_subdir(self):
 		return self._inst_yml.get('git_subdir', None)
 

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -15,8 +15,8 @@ DEFAULT_DEV_BUILD_NAME = '_dev'
 EXPERIMENTS_LIST_THRESHOLD = 30
 TIMEOUT_GRACE_PERIOD = 30
 DEFAULT_SOCKETPATH = os.path.expanduser('~/.extl.sock')
-
 DID_WARN_KONECT = False
+ADDITIONAL_SUPPORTED_ARCHIVE_FORMATS = ['gz']  # In addition to the formats supported by shutil.unpack_archive().
 
 did_warn_libyaml = False
 YmlLoader = yaml.SafeLoader
@@ -741,8 +741,10 @@ class Instance:
 		elif 'method' in self._inst_yml:
 			print(f"Downloading instance '{self.shortname}' with method '{self.method}'")
 
-			instances.download_instance(self._inst_yml,
+			ret_value = instances.download_instance(self._inst_yml,
 					self.config.instance_dir(), self.unique_filename, partial_path, '.post0')
+			if ret_value is not None:
+				return
 		else:
 			raise RuntimeError(f"Unknown installation option for instance '{self.shortname}'")
 

--- a/simexpal/schemes/experiments.json
+++ b/simexpal/schemes/experiments.json
@@ -232,6 +232,10 @@
 											"url": {"type": "string"},
 											"set": {"$ref": "#/definitions/str_or_str_list"},
 											"postprocess": {"const": "to_edgelist"},
+											"format": {
+												"type": "string",
+												"enum": ["zip", "tar", "gztar", "bztar", "xztar", "gz"]
+											},
 											"items": {
 												"oneOf": [
 													{

--- a/tests/instances/experiments_ymls/url/experiments.yml
+++ b/tests/instances/experiments_ymls/url/experiments.yml
@@ -5,3 +5,13 @@ instances:
     items:
       - 'experiments.json'
       - 'launchers.json'
+  - method: url
+    url: 'https://snap.stanford.edu/data/@INSTANCE_FILENAME@.txt.gz'
+    format: 'gz'
+    items:
+      - 'facebook_combined'
+  - method: url
+    url: 'http://nrvis.com/download/data/dynamic/soc-epinions-trust-dir.zip'
+    format: zip
+    items:
+      - 'soc-epinions-trust-dir.edges'


### PR DESCRIPTION
This PR contains the following:
- support automatic unpacking of URL isntances via a new ``format`` key
- documentation on automatic unpacking of URL instances
- tests for automatic unpacking of URL instances
- add some missing keys in [experiments.yml reference page](https://simexpal.readthedocs.io/en/latest/experiments_reference.html)