### PR TITLE
Adding requirements.txt for doc-build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
 	package_data={'simexpal': ['schemes/*.json']},
 	scripts=['scripts/simex'],
 	install_requires=[
+		'importlib-metadata==5.2.0',
 		'argcomplete',
 		'requests',
 		'pyyaml',


### PR DESCRIPTION
`importlib-metadata` just recently updated to version 6.0.0 and `argcomplete` currently pins to a version lower than 6. For RtD-builds, this leads to building errors. 

The additional `requirements.txt` file (pinning `importlib-metadata==5.2.0`) in docs-folder is automatically picked up by the builder and resolves this issue.