### PR TITLE
Pin importlib-metadata to <5.0 for argcomplete.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
 	package_data={'simexpal': ['schemes/*.json']},
 	scripts=['scripts/simex'],
 	install_requires=[
-		'importlib-metadata==5.2.0',
+		'importlib-metadata<5.0',
 		'argcomplete',
 		'requests',
 		'pyyaml',


### PR DESCRIPTION
Did a bit more testing, this PR should finally fix the unsuccessful Rtd builds. At least it does locally when reproducing the official pipeline from Rtd.