### PR TITLE
fix sorting example for pandas 2.x

### DIFF
--- a/examples/sorting/eval.py
+++ b/examples/sorting/eval.py
@@ -21,4 +21,4 @@ for successful_run in cfg.collect_successful_results():
 		results.append(parse(successful_run, f))
 
 df = pandas.DataFrame(results)
-print(df.groupby('experiment').agg('mean'))
+print(df.groupby('experiment')[['comparisons', 'swaps', 'time']].agg('mean'))


### PR DESCRIPTION
The current examples/sorting/eval.py causes an error with pandas 2.1.3, because we try to take the mean of a `object` type column (the `instance` column which is a string). This PR fixes that problem by selecting specific columns to take the mean. Previous versions of pandas implicitly dropped columns that were not numeric.

Full error for reference:
```py
Traceback (most recent call last):
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/groupby/groupby.py", line 1874, in _agg_py_fallback
    res_values = self.grouper.agg_series(ser, alt, preserve_dtype=True)
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/groupby/ops.py", line 850, in agg_series
    result = self._aggregate_series_pure_python(obj, func)
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/groupby/ops.py", line 871, in _aggregate_series_pure_python
    res = func(group)
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/groupby/groupby.py", line 2380, in <lambda>
    alt=lambda x: Series(x).mean(numeric_only=numeric_only),
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/series.py", line 6221, in mean
    return NDFrame.mean(self, axis, skipna, numeric_only, **kwargs)
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/generic.py", line 11984, in mean
    return self._stat_function(
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/generic.py", line 11941, in _stat_function
    return self._reduce(
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/series.py", line 6129, in _reduce
    return op(delegate, skipna=skipna, **kwds)
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/nanops.py", line 147, in f
    result = alt(values, axis=axis, skipna=skipna, **kwds)
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/nanops.py", line 404, in new_func
    result = func(values, axis=axis, skipna=skipna, mask=mask, **kwargs)
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/nanops.py", line 720, in nanmean
    the_sum = _ensure_numeric(the_sum)
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/nanops.py", line 1693, in _ensure_numeric
    raise TypeError(f"Could not convert string '{x}' to numeric")
TypeError: Could not convert string 'uniform-n1000-s1uniform-n1000-s2uniform-n1000-s3' to numeric

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/eval.py", line 27, in <module>
    print(df.groupby('experiment').agg('mean'))
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/groupby/generic.py", line 1445, in aggregate
    result = op.agg()
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/apply.py", line 172, in agg
    return self.apply_str()
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/apply.py", line 586, in apply_str
    return self._apply_str(obj, func, *self.args, **self.kwargs)
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/apply.py", line 669, in _apply_str
    return f(*args, **kwargs)
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/groupby/groupby.py", line 2378, in mean
    result = self._cython_agg_general(
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/groupby/groupby.py", line 1929, in _cython_agg_general
    new_mgr = data.grouped_reduce(array_func)
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/internals/managers.py", line 1428, in grouped_reduce
    applied = sb.apply(func)
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/internals/blocks.py", line 366, in apply
    result = func(self.values, **kwargs)
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/groupby/groupby.py", line 1926, in array_func
    result = self._agg_py_fallback(how, values, ndim=data.ndim, alt=alt)
  File "/home/berneluk/Dokumente/test/simexpal/examples/sorting/.venv/lib/python3.10/site-packages/pandas/core/groupby/groupby.py", line 1878, in _agg_py_fallback
    raise type(err)(msg) from err
TypeError: agg function failed [how->mean,dtype->object]
```