### PR TITLE
Clearly document ignored key for build_version

### DIFF
--- a/docs/revisions.rst
+++ b/docs/revisions.rst
@@ -63,7 +63,7 @@ are:
 
 Values specified for the ``build_version`` key will be ignored for develop
 revisions. Instead, the latest commit of the default branch will be checked out
-after cloning the repository.
+after cloning the repository initially.
 
 .. code-block:: YAML
    :linenos:

--- a/docs/revisions.rst
+++ b/docs/revisions.rst
@@ -61,8 +61,9 @@ are:
 - we add another key ``develop`` and set its value to ``true`` *and*
 - we leave the values of the ``build_version`` dict as empty string ``''``.
 
-Values specified in the ``build_version`` dict will be ignored for develop revisions and simexpal will clone the
-latest project files.
+Values specified for the ``build_version`` key will be ignored for develop
+revisions. Instead, the latest commit of the default branch will be checked out
+after cloning the repository.
 
 .. code-block:: YAML
    :linenos:
@@ -76,6 +77,8 @@ latest project files.
 
 .. note::
    It is possible to have normal and develop revisions at the same time.
+   Use the regular git commands within the cloned repositories used as 
+   develop revisions to switch branches or checkout to another commit.
 
 Next
 ----

--- a/docs/revisions.rst
+++ b/docs/revisions.rst
@@ -77,8 +77,9 @@ after cloning the repository initially.
 
 .. note::
    It is possible to have normal and develop revisions at the same time.
-   Use the regular git commands within the cloned repositories used as 
-   develop revisions to switch branches or checkout to another commit.
+   To operate on develop revision git **repositories**, you must first 
+   clone all repositories (e.g. `simex develop --checkout`). Thereafter, 
+   navigate to the respective **repositories** and use regular git commands.
 
 Next
 ----


### PR DESCRIPTION
The build_version key will simply be ignored in develop revisions. This is now documented clearly.

This PR addresses #141 