### PR TITLE
Fileless Instances: Document & Give Hint to User

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ simexpal.egg-info/
 *aux/
 *instances/
 
+examples/*/validation.cache
+

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ simexpal.egg-info/
 *instances/
 
 examples/*/validation.cache
+examples/*/status.cache
 

--- a/docs/instances.rst
+++ b/docs/instances.rst
@@ -266,6 +266,11 @@ key to specify our extra arguments.
             files: []
             extra_args: ['--seed', '10']
 
+.. note::
+   If you get an error message pointing out that the experiment is fileless, check if  you forgot to 
+   remove the ``@INSTANCE@`` variable in the experiment argument list. Since the experiment does not 
+   take an instance as input, this variable must not be part of the argument list!
+
 Generator Instances
 -------------------
 

--- a/examples/sorting_fileless/eval.py
+++ b/examples/sorting_fileless/eval.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+import simexpal
+import pandas
+import yaml
+
+def parse(run, f):
+	output = yaml.load(f, Loader=yaml.Loader)
+	return {
+		'experiment': run.experiment.name,
+		'instance': run.instance.shortname,
+		'comparisons': output['comparisons'],
+		'swaps': output['swaps'],
+		'time': output['time']
+	}
+
+cfg = simexpal.config_for_dir()
+results = []
+for successful_run in cfg.collect_successful_results():
+	with successful_run.open_output_file() as f:
+		results.append(parse(successful_run, f))
+
+df = pandas.DataFrame(results)
+print(df.groupby('experiment')[['comparisons', 'swaps', 'time']].agg('mean'))

--- a/examples/sorting_fileless/experiments.yml
+++ b/examples/sorting_fileless/experiments.yml
@@ -1,0 +1,27 @@
+instances:
+  - repo: local
+    set: [file_less]
+    items:
+      - name: uniform-n1000-s1
+        files: []
+        extra_args: ['--seed=1', '1000']
+      - name: uniform-n1000-s2
+        files: []
+        extra_args: ['--seed=2', '1000']
+      - name: uniform-n1000-s3
+        files: []
+        extra_args: ['--seed=3', '1000']
+
+experiments:
+  - name: insertion-sort
+    args: ['./sort.py', '@EXTRA_ARGS@', '--algo=insertion-sort']
+    stdout: out
+  - name: bubble-sort
+    args: ['./sort.py', '@EXTRA_ARGS@', '--algo=bubble-sort']
+    stdout: out
+
+matrix:
+  include:
+    - experiments: [insertion-sort, bubble-sort]
+      instsets: [file_less]
+      axes: []

--- a/examples/sorting_fileless/sort.py
+++ b/examples/sorting_fileless/sort.py
@@ -75,19 +75,16 @@ def run_experiment(algo, array):
 
 def do_main():
 	parser = argparse.ArgumentParser()
-	parser.add_argument('-o', type=str, help="path of output file", default="/dev/stdout")
 	parser.add_argument('--seed', type=int, help="seed for random generator")
-	parser.add_argument('--range', type=int, help="range of integers", default=10e6)
 	parser.add_argument('n', type=int, help="number of integers to generate")
 	parser.add_argument('--algo', type=str, choices=['bubble-sort', 'insertion-sort'])
-	parser.add_argument('instance', type=str)
 
 	args = parser.parse_args()
 
 	numbers = []
 	random.seed(args.seed)
 	for i in range(args.n):
-		numbers.append(random.randint(1, args.range))
+		numbers.append(random.randint(1, 10e6))
 
 	args = parser.parse_args()
 	run_experiment(args.algo, numbers)

--- a/examples/sorting_fileless/sort.py
+++ b/examples/sorting_fileless/sort.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+from time import time
+import yaml
+import argparse
+import random
+
+n_comparisons = 0
+n_swaps = 0
+
+def insertion_sort(array):
+	global n_comparisons
+	global n_swaps
+
+	for i in range(1, len(array)):
+		elem = array[i]
+		for k in range(i):
+			n_comparisons += 1
+			if array[k] > elem:
+				break
+		for j in reversed(range(k + 1, i)):
+			n_swaps += 1
+			array[j + 1] = array[j]
+		array[k] = elem
+	return array
+
+def bubble_sort(array):
+	global n_comparisons
+	global n_swaps
+
+	for i in range(len(array)):
+		for j in reversed(range(i + 1, len(array))):
+			n_comparisons += 1
+			if array[j] < array[j - 1]:
+				n_swaps += 1
+				array[j], array[j - 1] = array[j - 1], array[j]
+	return array
+
+def write_result(algo, sorted_array, t):
+	result_dict = {
+		'algo' : algo,
+		'result' : sorted_array,
+		'comparisons': n_comparisons,
+		'swaps': n_swaps,
+		'time' : t
+	}
+	print(yaml.dump(result_dict, default_flow_style=False))
+
+def read_list(instance):
+	try:
+		with open(instance, 'r') as f:
+			l = [int(line.strip()) for line in f]
+			return l
+	except IOError as error:
+		raise
+
+def run_experiment(algo, array):
+	t = 0
+	sorted_array = []
+	if algo == 'bubble-sort':
+		t = -time()
+		sorted_array = bubble_sort(array)
+		t += time()
+	elif algo == 'insertion-sort':
+		t = -time()
+		sorted_array = insertion_sort(array)
+		t += time()
+	else:
+		print("Unknown algorithm: ", algo, file=sys.stderr)
+		sys.exit(1)
+
+	write_result(algo, sorted_array, t)
+
+def do_main():
+	parser = argparse.ArgumentParser()
+	parser.add_argument('-o', type=str, help="path of output file", default="/dev/stdout")
+	parser.add_argument('--seed', type=int, help="seed for random generator")
+	parser.add_argument('--range', type=int, help="range of integers", default=10e6)
+	parser.add_argument('n', type=int, help="number of integers to generate")
+	parser.add_argument('--algo', type=str, choices=['bubble-sort', 'insertion-sort'])
+	parser.add_argument('instance', type=str)
+
+	args = parser.parse_args()
+
+	numbers = []
+	random.seed(args.seed)
+	for i in range(args.n):
+		numbers.append(random.randint(1, args.range))
+
+	args = parser.parse_args()
+	run_experiment(args.algo, numbers)
+
+do_main()

--- a/simexpal/launch/common.py
+++ b/simexpal/launch/common.py
@@ -347,7 +347,7 @@ def invoke_run(manifest):
 	def substitute(p):
 		if p == 'INSTANCE':
 			if manifest.instance_is_filess:
-				raise RuntimeError(f"The instance '{manifest.instance}' is fileless")
+				raise RuntimeError(f"The instance '{manifest.instance}' is fileless. Did you forget to remove the @INSTANCE@ variable in the argument list of the experiment?")
 
 			return manifest.instance_dir + '/' + manifest.instance_name
 		elif p.startswith('INSTANCE:'):


### PR DESCRIPTION
With this PR we address the issue #130. For fileless instances, the user did only get a somewhat cryptic error message in case they forgot to remove the `@INSTANCE@` variable in the experiment argument list. 

Two issues are addressed:

1. Provide a better error message if `@INSTANCE@` is part of the experiment arguments for a fileless experiment.
2. Give a hint to the user in the documentation to not add (or remove) the `@INSTANCE@` variable.