### PR TITLE
Autocomplete documentation

### DIFF
--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -126,6 +126,15 @@ on multiple inputs.
     (i.e., the functions ``collect_successful_results()`` and ``open_output_file()``)
     to gather all results. It uses ``pandas`` to aggregate statistics over all experiments.
 
+.. tip::
+    Simexpal supports autocomplete via `argcomplete <https://pypi.org/project/argcomplete/>`.
+    To enable autocomplete, install ``argcomplete`` and enable global completion:
+
+    .. code-block:: bash
+
+      $ pip install argcomplete
+      $ activate-global-python-argcomplete
+
 Running Experiments
 -------------------
 

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -132,7 +132,7 @@ on multiple inputs.
 
     .. code-block:: bash
 
-      $ pip install argcomplete
+      $ pip3 install argcomplete
       $ activate-global-python-argcomplete
 
 Running Experiments


### PR DESCRIPTION
Adds a tip in the Quick Start guide that autocomplete is usable (#129)