### PR TITLE
Fix ReadTheDocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,4 @@
-# Set the OS, Python version and other tools you might need
+version: 2
 
 build:
   os: ubuntu-22.04
@@ -9,3 +9,7 @@ build:
 
 sphinx:
   configuration: docs/conf.py
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,11 @@
+# Set the OS, Python version and other tools you might need
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+# Build documentation in the "docs/" directory with Sphinx
+
+sphinx:
+  configuration: docs/conf.py

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx
+sphinx-rtd-theme
+readthedocs-sphinx-ext
+jinja2


### PR DESCRIPTION
Read the docs seems to have added the requirement of a config file. This PR adds this config file and also the requirements for a doc-build (like theme). Successful builds from this branch can be seen here: https://simexpal-doctester.readthedocs.io/en/20240109_fix_rtd/