### PR TITLE
Check for undefined variants and axes

### DIFF
--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -613,9 +613,10 @@ class Config:
 						return False
 			return True
 
-		for variant in scope.variants:
-			if variant not in self._variants:
-				raise RuntimeError("Variant {} does not exist".format(variant))
+		if scope.variants is not None:
+			for variant in scope.variants:
+				if variant not in self._variants:
+					raise RuntimeError("Variant {} does not exist".format(variant))
 
 		if scope.axes is None:
 			axes = self._axes.keys()
@@ -1495,4 +1496,3 @@ def config_for_dir(basedir=None):
 		basedir = '.'
 	yml = util.validate_setup_file(basedir, 'experiments.yml', 'experiments.json')
 	return Config(os.path.abspath(basedir), yml)
-

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -171,7 +171,7 @@ class Config:
 					raise RuntimeError("The revision name '{}' is ambiguous".format(revision.name))
 				self._revisions[revision.name] = revision
 
-		for axis in sorted(construct_axes(), key=lambda axis: axis):
+		for axis in sorted(construct_axes()):
 			if axis in self._axes:
 				raise RuntimeError("The axis name '{}' is ambiguous".format(axis))
 			self._axes[axis] = axis

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -613,6 +613,10 @@ class Config:
 						return False
 			return True
 
+		for variant in scope.variants:
+			if variant not in self._variants:
+				raise RuntimeError("Variant {} does not exist".format(variant))
+
 		if scope.axes is None:
 			axes = self._axes.keys()
 		else:

--- a/tests/experiments/experiments_ymls/undefined_axes/experiments.yml
+++ b/tests/experiments/experiments_ymls/undefined_axes/experiments.yml
@@ -54,6 +54,7 @@ matrix:
       variants: [ba-insert, bs32]
       revisions: [main]
     - experiments: [quick-sort]
-      # The following axis contains a typo
+      # The following axis contains a typo:
+      # "block.size" instead of "block-size"
       axes: [block.size]
       revisions: [main]

--- a/tests/experiments/experiments_ymls/undefined_axes/experiments.yml
+++ b/tests/experiments/experiments_ymls/undefined_axes/experiments.yml
@@ -1,0 +1,56 @@
+builds:
+  - name: simexpal
+    git: 'https://github.com/hu-macsy/simexpal'
+    configure:
+      - args:
+          - 'cmake'
+          - '-DCMAKE_INSTALL_PREFIX=@THIS_PREFIX_DIR@'
+          - '@THIS_CLONE_DIR@/examples/sorting_cpp/'
+    compile:
+      - args:
+          - 'make'
+          - '-j@PARALLELISM@'
+    install:
+      - args:
+          - 'make'
+          - 'install'
+
+revisions:
+  - name: main
+    build_version:
+      'simexpal': 'd8d421e3c2eaa32311a6c678b15e9e22ea0d8eac'
+
+instances:
+  - repo: local
+    items:
+      - uniform-n1000-s1
+      - uniform-n1000-s2
+
+experiments:
+  - name: quick-sort
+    use_builds: [simexpal]
+    args: ['quicksort', '@INSTANCE@', '@EXTRA_ARGS@']
+    stdout: out
+
+variants:
+  - axis: 'block-algo'
+    items:
+      - name: 'ba-insert'
+        extra_args: ['insertion_sort']
+      - name: 'ba-bubble'
+        extra_args: ['bubble_sort']
+  - axis: 'block-size'
+    items:
+      - name: 'bs32'
+        extra_args: ['32']
+      - name: 'bs64'
+        extra_args: ['64']
+
+matrix:
+  include:
+    - experiments: [quick-sort]
+      variants: [ba-insert, bs32]
+      revisions: [main]
+    - experiments: [quick-sort]
+      axes: [block.size]
+      revisions: [main]

--- a/tests/experiments/experiments_ymls/undefined_axes/experiments.yml
+++ b/tests/experiments/experiments_ymls/undefined_axes/experiments.yml
@@ -1,3 +1,5 @@
+# This file is identical to examples/sorting/sorting_cpp
+# except for a minor typo
 builds:
   - name: simexpal
     git: 'https://github.com/hu-macsy/simexpal'
@@ -52,5 +54,6 @@ matrix:
       variants: [ba-insert, bs32]
       revisions: [main]
     - experiments: [quick-sort]
+      # The following axis contains a typo
       axes: [block.size]
       revisions: [main]

--- a/tests/experiments/experiments_ymls/undefined_variant/experiments.yml
+++ b/tests/experiments/experiments_ymls/undefined_variant/experiments.yml
@@ -1,0 +1,56 @@
+builds:
+  - name: simexpal
+    git: 'https://github.com/hu-macsy/simexpal'
+    configure:
+      - args:
+          - 'cmake'
+          - '-DCMAKE_INSTALL_PREFIX=@THIS_PREFIX_DIR@'
+          - '@THIS_CLONE_DIR@/examples/sorting_cpp/'
+    compile:
+      - args:
+          - 'make'
+          - '-j@PARALLELISM@'
+    install:
+      - args:
+          - 'make'
+          - 'install'
+
+revisions:
+  - name: main
+    build_version:
+      'simexpal': 'd8d421e3c2eaa32311a6c678b15e9e22ea0d8eac'
+
+instances:
+  - repo: local
+    items:
+      - uniform-n1000-s1
+      - uniform-n1000-s2
+
+experiments:
+  - name: quick-sort
+    use_builds: [simexpal]
+    args: ['quicksort', '@INSTANCE@', '@EXTRA_ARGS@']
+    stdout: out
+
+variants:
+  - axis: 'block-algo'
+    items:
+      - name: 'ba-insert'
+        extra_args: ['insertion_sort']
+      - name: 'ba-bubble'
+        extra_args: ['bubble_sort']
+  - axis: 'block-size'
+    items:
+      - name: 'bs32'
+        extra_args: ['32']
+      - name: 'bs64'
+        extra_args: ['64']
+
+matrix:
+  include:
+    - experiments: [quick-sort]
+      variants: [ba-insert, bs32]
+      revisions: [main]
+    - experiments: [quick-sort]
+      variants: [ba-buble]
+      revisions: [main]

--- a/tests/experiments/experiments_ymls/undefined_variant/experiments.yml
+++ b/tests/experiments/experiments_ymls/undefined_variant/experiments.yml
@@ -1,3 +1,5 @@
+# This file is identical to examples/sorting/sorting_cpp
+# except for a minor typo
 builds:
   - name: simexpal
     git: 'https://github.com/hu-macsy/simexpal'
@@ -52,5 +54,6 @@ matrix:
       variants: [ba-insert, bs32]
       revisions: [main]
     - experiments: [quick-sort]
+      # The following variant contains a typo
       variants: [ba-buble]
       revisions: [main]

--- a/tests/experiments/experiments_ymls/undefined_variant/experiments.yml
+++ b/tests/experiments/experiments_ymls/undefined_variant/experiments.yml
@@ -1,5 +1,5 @@
 # This file is identical to examples/sorting/sorting_cpp
-# except for a minor typo
+# except for an undefined variant
 builds:
   - name: simexpal
     git: 'https://github.com/hu-macsy/simexpal'
@@ -54,6 +54,6 @@ matrix:
       variants: [ba-insert, bs32]
       revisions: [main]
     - experiments: [quick-sort]
-      # The following variant contains a typo
-      variants: [ba-buble]
+      # The following variant does not exist
+      variants: [undefined-variant]
       revisions: [main]

--- a/tests/experiments/test_status_file.py
+++ b/tests/experiments/test_status_file.py
@@ -15,8 +15,8 @@ valid_experiments = ['../../examples/sorting',
                      '../../examples/download_instances'
                      ]
 
-invalid_experiments = ['experiments_ymls/undefined_axes',
-                       'experiments_ymls/undefined_variant'
+invalid_experiments = [('experiments_ymls/undefined_axes', 'Axis block.size does not exist'),
+                       ('experiments_ymls/undefined_variant', 'Variant undefined-variant does not exist')
                        ]
 
 @pytest.mark.parametrize('rel_yml_path', yml_dirs)
@@ -44,12 +44,14 @@ def test_valid_experiments(rel_exp_path):
 
     assert isinstance(cfg, base.Config)
 
-@pytest.mark.parametrize('rel_exp_path', invalid_experiments)
-def test_invalid_experiments(rel_exp_path):
+@pytest.mark.parametrize('rel_exp_path, error_message', invalid_experiments)
+def test_invalid_experiments(rel_exp_path, error_message):
     experiments_dir = os.path.join(file_dir, rel_exp_path)
     cfg = base.config_for_dir(experiments_dir)
 
     assert isinstance(cfg, base.Config)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as error:
         a = list(cfg.discover_all_runs())
+
+    assert error_message == str(error.value)

--- a/tests/experiments/test_status_file.py
+++ b/tests/experiments/test_status_file.py
@@ -9,6 +9,16 @@ file_dir = os.path.abspath(os.path.dirname(__file__))
 
 yml_dirs = ['/experiments_ymls/missing_program']
 
+valid_experiments = ['../../examples/sorting',
+                     '../../examples/sorting_cpp',
+                     '../../examples/sorting_fileless',
+                     '../../examples/download_instances'
+                     ]
+
+invalid_experiments = ['experiments_ymls/undefined_axes',
+                       'experiments_ymls/undefined_variant'
+                       ]
+
 @pytest.mark.parametrize('rel_yml_path', yml_dirs)
 def test_experiments_missing_program(rel_yml_path):
     cfg = base.config_for_dir(file_dir + rel_yml_path)
@@ -26,3 +36,20 @@ def test_experiments_missing_program(rel_yml_path):
 
         assert run.get_status() == base.Status.FAILED
         assert os.path.getsize(run.aux_file_path('stderr'))
+
+@pytest.mark.parametrize('rel_exp_path', valid_experiments)
+def test_valid_experiments(rel_exp_path):
+    experiments_dir = os.path.join(file_dir, rel_exp_path)
+    cfg = base.config_for_dir(experiments_dir)
+
+    assert isinstance(cfg, base.Config)
+
+@pytest.mark.parametrize('rel_exp_path', invalid_experiments)
+def test_invalid_experiments(rel_exp_path):
+    experiments_dir = os.path.join(file_dir, rel_exp_path)
+    cfg = base.config_for_dir(experiments_dir)
+
+    assert isinstance(cfg, base.Config)
+
+    with pytest.raises(RuntimeError):
+        a = list(cfg.discover_all_runs())


### PR DESCRIPTION
Addresses #135 and #137: when an undefined variant or axes is used in the experiments matrix, an error is thrown
- adds new `Config._axes` field (currently an `OrderedDict` with the value being the key itself)
- adds two simple test experiment setup files with an undefined variant and an undefined axes (identical to `examples/sorting/sorting_cpp` except for minor typos)