### PR TITLE
Add Slurm exclusive flag

### DIFF
--- a/docs/experiments.rst
+++ b/docs/experiments.rst
@@ -329,7 +329,7 @@ the ``experiments.yml``:
 - ``procs_per_node``: number of tasks to invoke on each node (slurm: ``--ntasks-per-node=n``)
 - ``num_threads``:    number of cpus required per task (slurm: ``-c``, ``--cpus-per-task=ncpus``)
 - ``num_nodes``:      number of nodes on which to run (N = min[-max]) (slurm: ``-N``, ``--nodes=N``)
-- ``exclusive``:      boolean to set the ``--exclusive`` flag, so the job allocation reserves all resources of a node
+- ``exclusive``:      boolean flag to run an experiment exclusively on specified computing resources (slurm: ``--exclusive``)
 
 .. code-block:: YAML
    :linenos:

--- a/docs/experiments.rst
+++ b/docs/experiments.rst
@@ -327,8 +327,9 @@ Currently, simexpal supports the following three ``sbatch`` parameters by using 
 the ``experiments.yml``:
 
 - ``procs_per_node``: number of tasks to invoke on each node (slurm: ``--ntasks-per-node=n``)
-- ``num_threads``: number of cpus required per task (slurm: ``-c``, ``--cpus-per-task=ncpus``)
-- ``num_nodes``: number of nodes on which to run (N = min[-max]) (slurm: ``-N``, ``--nodes=N``)
+- ``num_threads``:    number of cpus required per task (slurm: ``-c``, ``--cpus-per-task=ncpus``)
+- ``num_nodes``:      number of nodes on which to run (N = min[-max]) (slurm: ``-N``, ``--nodes=N``)
+- ``exclusive``:      boolean to set the ``--exclusive`` flag, so the job allocation reserves all resources of a node
 
 .. code-block:: YAML
    :linenos:

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -1213,20 +1213,7 @@ class Experiment:
 		return self.info.thread_settings
 
 	@property
-	def is_effective_exclusive(self):
-		s = None
-		for variant in self.variation:
-			vs = variant.is_exclusive
-			if vs is None:
-				continue
-			if s is not None and s.is_exclusive != vs:
-				raise RuntimeError("Exclusive flag for experiments '{}' overridden by multiple variants: {}".format(
-					self.name, [s.name, variant.name]
-				))
-			s = variant
-
-		if s is not None:
-			return s.is_exclusive
+	def is_exclusive(self):
 		return self.info.is_exclusive
 
 	@property

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -1056,6 +1056,10 @@ class Variant:
 		return extract_thread_settings(self.variant_yml)
 
 	@property
+	def is_exclusive(self):
+		return self.variant_yml.get('exclusive', False)
+
+	@property
 	def slurm_args(self):
 		return self.variant_yml.get('slurm_args', [])
 
@@ -1093,6 +1097,10 @@ class ExperimentInfo:
 	@property
 	def thread_settings(self):
 		return extract_thread_settings(self._exp_yml)
+	
+	@property
+	def is_exclusive(self):
+		return self._exp_yml.get('exclusive', False)
 
 	@property
 	def slurm_args(self):
@@ -1203,6 +1211,23 @@ class Experiment:
 		if s is not None:
 			return s.thread_settings
 		return self.info.thread_settings
+
+	@property
+	def is_effective_exclusive(self):
+		s = None
+		for variant in self.variation:
+			vs = variant.is_exclusive
+			if not vs:
+				continue
+			if s:
+				raise RuntimeError("Exclusive flag for experiments '{}' overridden by multiple variants: {}".format(
+					self.name, [s.name, variant.name]
+				))
+			s = variant
+
+		if s is not None:
+			return s.is_exclusive
+		return self.info.is_exclusive
 
 	@property
 	def display_name(self):

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -1057,7 +1057,7 @@ class Variant:
 
 	@property
 	def is_exclusive(self):
-		return self.variant_yml.get('exclusive', False)
+		return self.variant_yml.get('exclusive', None)
 
 	@property
 	def slurm_args(self):
@@ -1100,7 +1100,7 @@ class ExperimentInfo:
 	
 	@property
 	def is_exclusive(self):
-		return self._exp_yml.get('exclusive', False)
+		return self._exp_yml.get('exclusive', None)
 
 	@property
 	def slurm_args(self):
@@ -1217,9 +1217,9 @@ class Experiment:
 		s = None
 		for variant in self.variation:
 			vs = variant.is_exclusive
-			if not vs:
+			if vs is None:
 				continue
-			if s:
+			if s is not None and s.is_exclusive != vs:
 				raise RuntimeError("Exclusive flag for experiments '{}' overridden by multiple variants: {}".format(
 					self.name, [s.name, variant.name]
 				))

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -1191,9 +1191,7 @@ class Experiment:
 				))
 			s = variant
 
-		if s is not None:
-			return s.process_settings
-		return self.info.process_settings
+		return s.process_settings if s is not None else self.info.process_settings
 
 	@property
 	def effective_thread_settings(self):
@@ -1208,9 +1206,7 @@ class Experiment:
 				))
 			s = variant
 
-		if s is not None:
-			return s.thread_settings
-		return self.info.thread_settings
+		return s.thread_settings if s is not None else self.info.thread_settings
 
 	@property
 	def is_exclusive(self):

--- a/simexpal/launch/slurm.py
+++ b/simexpal/launch/slurm.py
@@ -125,13 +125,13 @@ class SlurmLauncher(common.Launcher):
 		sbatch_args = ['sbatch', '-J', experiment.display_name]
 		if self.queue:
 			sbatch_args += ['-p', self.queue]
-		if not experiment.is_effective_exclusive:
-			if ps and ps['num_nodes']:
-				sbatch_args += ['-N', str(ps['num_nodes'])]
+		if experiment.is_effective_exclusive:
+			sbatch_args += ['--exclusive']
+		else:
 			if ts and ts['num_threads']:
 				sbatch_args += ['-c', str(ts['num_threads'])]
-		else:
-			sbatch_args += ['--exclusive']
+		if ps and ps['num_nodes']:
+			sbatch_args += ['-N', str(ps['num_nodes'])]
 		if ps and ps['procs_per_node']:
 			sbatch_args += ['--ntasks-per-node', str(ps['procs_per_node'])]
 		log_pattern = '%A-%a' if use_array else '%A'

--- a/simexpal/launch/slurm.py
+++ b/simexpal/launch/slurm.py
@@ -125,12 +125,15 @@ class SlurmLauncher(common.Launcher):
 		sbatch_args = ['sbatch', '-J', experiment.display_name]
 		if self.queue:
 			sbatch_args += ['-p', self.queue]
-		if ps and ps['num_nodes']:
-			sbatch_args += ['-N', str(ps['num_nodes'])]
+		if not experiment.is_effective_exclusive:
+			if ps and ps['num_nodes']:
+				sbatch_args += ['-N', str(ps['num_nodes'])]
+			if ts and ts['num_threads']:
+				sbatch_args += ['-c', str(ts['num_threads'])]
+		else:
+			sbatch_args += ['--exclusive']
 		if ps and ps['procs_per_node']:
 			sbatch_args += ['--ntasks-per-node', str(ps['procs_per_node'])]
-		if ts and ts['num_threads']:
-			sbatch_args += ['-c', str(ts['num_threads'])]
 		log_pattern = '%A-%a' if use_array else '%A'
 		sbatch_args.extend(['-o', os.path.join(cfg.basedir, 'aux/_slurm/' + log_pattern + '.out'),
 				'-e', os.path.join(cfg.basedir, 'aux/_slurm/' + log_pattern + '.err')])

--- a/simexpal/launch/slurm.py
+++ b/simexpal/launch/slurm.py
@@ -127,9 +127,8 @@ class SlurmLauncher(common.Launcher):
 			sbatch_args += ['-p', self.queue]
 		if experiment.is_exclusive:
 			sbatch_args += ['--exclusive']
-		else:
-			if ts and ts['num_threads']:
-				sbatch_args += ['-c', str(ts['num_threads'])]
+		if ts and ts['num_threads']:
+			sbatch_args += ['-c', str(ts['num_threads'])]
 		if ps and ps['num_nodes']:
 			sbatch_args += ['-N', str(ps['num_nodes'])]
 		if ps and ps['procs_per_node']:

--- a/simexpal/launch/slurm.py
+++ b/simexpal/launch/slurm.py
@@ -125,7 +125,7 @@ class SlurmLauncher(common.Launcher):
 		sbatch_args = ['sbatch', '-J', experiment.display_name]
 		if self.queue:
 			sbatch_args += ['-p', self.queue]
-		if experiment.is_effective_exclusive:
+		if experiment.is_exclusive:
 			sbatch_args += ['--exclusive']
 		else:
 			if ts and ts['num_threads']:

--- a/simexpal/schemes/experiments.json
+++ b/simexpal/schemes/experiments.json
@@ -40,40 +40,24 @@
 		},
 		"slurm_settings": {
 			"type": "object",
-			"allOf": [
-				{
-					"not": {
-						"anyOf": [
-							{
-								"required": ["exclusive", "num_threads"],
-								"properties": {
-									"exclusive": { "const": true }
-								}
-							}
-						]
-					}
+			"properties": {
+				"num_nodes": {
+					"type": ["integer", "string"],
+					"minimum": 1
 				},
-				{
-					"properties": {
-						"num_nodes": {
-							"type": ["integer", "string"],
-							"minimum": 1
-						},
-						"procs_per_node": {
-							"type":  ["integer", "string"],
-							"minimum": 1
-						},
-						"num_threads": {
-							"type": ["integer", "string"],
-							"minimum": 1
-						},
-						"slurm_args": {"$ref": "#/definitions/str_or_str_list"},
-						"exclusive": {
-							"type": "boolean"
-						}
-					}
+				"procs_per_node": {
+					"type":  ["integer", "string"],
+					"minimum": 1
+				},
+				"num_threads": {
+					"type": ["integer", "string"],
+					"minimum": 1
+				},
+				"slurm_args": {"$ref": "#/definitions/str_or_str_list"},
+				"exclusive": {
+					"type": "boolean"
 				}
-			]
+			}
 		}
 	},
 

--- a/simexpal/schemes/experiments.json
+++ b/simexpal/schemes/experiments.json
@@ -501,7 +501,6 @@
 										"num_nodes": {},
 										"procs_per_node": {},
 										"num_threads": {},
-										"exclusive": {},
 										"slurm_args": {}
 									},
 									"additionalProperties": false
@@ -532,7 +531,6 @@
 										"num_nodes": {},
 										"procs_per_node": {},
 										"num_threads": {},
-										"exclusive": {},
 										"slurm_args": {}
 									},
 									"additionalProperties": false
@@ -589,7 +587,6 @@
 													"num_nodes": {},
 													"procs_per_node": {},
 													"num_threads": {},
-													"exclusive": {},
 													"slurm_args": {}
 												},
 												"additionalProperties": false

--- a/simexpal/schemes/experiments.json
+++ b/simexpal/schemes/experiments.json
@@ -45,12 +45,6 @@
 					"not": {
 						"anyOf": [
 							{
-								"required": ["exclusive", "num_nodes"],
-								"properties": {
-									"exclusive": { "const": true }
-								}
-							},
-							{
 								"required": ["exclusive", "num_threads"],
 								"properties": {
 									"exclusive": { "const": true }

--- a/simexpal/schemes/experiments.json
+++ b/simexpal/schemes/experiments.json
@@ -40,21 +40,46 @@
 		},
 		"slurm_settings": {
 			"type": "object",
-			"properties": {
-				"num_nodes": {
-					"type": ["integer", "string"],
-					"minimum": 1
+			"allOf": [
+				{
+					"not": {
+						"anyOf": [
+							{
+								"required": ["exclusive", "num_nodes"],
+								"properties": {
+									"exclusive": { "const": true }
+								}
+							},
+							{
+								"required": ["exclusive", "num_threads"],
+								"properties": {
+									"exclusive": { "const": true }
+								}
+							}
+						]
+					}
 				},
-				"procs_per_node": {
-					"type":  ["integer", "string"],
-					"minimum": 1
-				},
-				"num_threads": {
-					"type": ["integer", "string"],
-					"minimum": 1
-				},
-				"slurm_args": {"$ref": "#/definitions/str_or_str_list"}
-			}
+				{
+					"properties": {
+						"num_nodes": {
+							"type": ["integer", "string"],
+							"minimum": 1
+						},
+						"procs_per_node": {
+							"type":  ["integer", "string"],
+							"minimum": 1
+						},
+						"num_threads": {
+							"type": ["integer", "string"],
+							"minimum": 1
+						},
+						"slurm_args": {"$ref": "#/definitions/str_or_str_list"},
+						"exclusive": {
+							"type": "boolean"
+						}
+					}
+				}
+			]
 		}
 	},
 
@@ -442,6 +467,7 @@
 							"num_nodes": {},
 							"procs_per_node": {},
 							"num_threads": {},
+							"exclusive": {},
 							"slurm_args": {}
 						},
 						"additionalProperties": false
@@ -481,6 +507,7 @@
 										"num_nodes": {},
 										"procs_per_node": {},
 										"num_threads": {},
+										"exclusive": {},
 										"slurm_args": {}
 									},
 									"additionalProperties": false
@@ -511,6 +538,7 @@
 										"num_nodes": {},
 										"procs_per_node": {},
 										"num_threads": {},
+										"exclusive": {},
 										"slurm_args": {}
 									},
 									"additionalProperties": false
@@ -567,6 +595,7 @@
 													"num_nodes": {},
 													"procs_per_node": {},
 													"num_threads": {},
+													"exclusive": {},
 													"slurm_args": {}
 												},
 												"additionalProperties": false


### PR DESCRIPTION
Addresses #143:
- adds new `exclusive` property to the Slurm launch properties
- if `exclusive: true` is set, the `--exclusive` flag is added to the Slurm arguments
 