### PR TITLE
Revise CLI Documentation

### DIFF
--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -44,19 +44,19 @@ command above).
 
 It further supports the following additional arguments:
 
-:``--checkout``: deletes the local Git repository and (re-)clones it.
-:``--compile``: (re-)compiles the build.
-:``--configure``: (re-)configures the build.
-:``--delete-source``: deletes the source directory when purging.
-:``--install``: (re-)installs the build.
-:``--purge``: deletes all related build files.
-:``--recheckout``: deletes the local build Git repository, reclones, regenerates, reconfigures, recompiles
-    and reinstalls it.
-:``--recompile``: recompiles and reinstall the build.
-:``--reconfigure``: reconfigures, recompiles and reinstalls the build.
-:``--regenerate``: (re-)regenerates the build.
-:``--reinstall``: reinstalls the build.
-:``--reregenerate``: regenerates, reconfigures, recompiles and reinstalls the build.
+:--checkout:      Deletes the local Git repository and clones it.
+:--compile:       Compiles the build.
+:--configure:     Configures the build.
+:--delete-source: Deletes the source directory when purging.
+:--install:       Installs the build files.
+:--purge:         Deletes all related build files.
+:--recheckout:    Deletes the cloned git repository, re-clones, regenerates,
+                  reconfigures, re-compiles, and reinstalls it.
+:--recompile:     Re-compiles and reinstall the build.
+:--reconfigure:   Re-configures the build.
+:--regenerate:    Re-generates the build.
+:--reinstall:     Re-installs the build.
+:--reregenerate:  Re-generates, re-configures, re-compiles, and reinstalls the build.
 
 The ``--checkout``, ``--recheckout`` and ``--purge`` arguments further require the ``-f`` argument to confirm
 their actions.
@@ -89,18 +89,23 @@ accepts the following actions flags:
 All the above actions can be applied to a subset of experiments according to a `selection option`,
 which can be specified as an additional argument. Supported selection options are:
 
-:``--all``: selects all the experiments.
-:``--axes [axes...]``: selects all experiments with the variant axes from the space separated list of axes.
-:``--run <r>``: selects the single run given as ``<experiment_display_name>/<instance>``, where
-    ``<experiment_display_name>`` is the name of the experiment as displayed on the command-line and
-    ``<instance>`` is the instance name as displayed on the command-line.
-:``--experiment <e>``: selects the experiment named ``e``.
-:``--failed``: selects all the failed experiments.
-:``--instance <i>``: selects all experiments with the instance named ``i``.
-:``--instset <i>``: selects all experiments with the instance set named ``i``.
-:``--unfinished``: selects all the unfinished experiments.
-:``--revision <i>``: selects all experiments with the revision named ``r``.
-:``--variants [variants...]``: selects all experiments with the variants from the space separated list of variants.
+:--all:                    Selects all the experiments.
+:--axes [axes...]:         Selects all experiments with the variant axes from
+                           the space separated list of *axes*.
+:--run <r>:                Selects the single run given as
+                           ``<experiment_display_name>/<instance>``, where
+                           ``<experiment_display_name>`` is the name of the
+                           experiment as displayed on the command-line and
+                           ``<instance>`` is the instance name as displayed on
+                           the command-line.
+:--experiment <e>:         Selects the experiment named *e*.
+:--failed:                 Selects all the failed experiments.
+:--instance <i>:           Selects all experiments with the instance named *i*.
+:--instset <i>:            Selects all experiments with the instance set named *i*.
+:--unfinished:             Selects all the unfinished experiments.
+:--revision <i>:           Selects all experiments with the revision named *r*.
+:--variants [variants...]: Selects all experiments with the variants from the
+                           space separated list of variants.
 
 instances
 ---------

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -83,8 +83,8 @@ accepts the following actions flags:
 
 :purge:  Deletes the experimental data. To confirm this action it needs the ``-f`` argument.
 
-:kill:   Terminates jobs submitted to or started by Slurm. To confirm this
-         action it needs the ``-f`` argument.
+:kill:   Terminates jobs submitted to or started by the scheduler. To confirm
+         this action it needs the ``-f`` argument.
 
 All the above actions can be applied to a subset of experiments according to a `selection option`,
 which can be specified as an additional argument. Supported selection options are:

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -104,14 +104,19 @@ which can be specified as an additional argument. Supported selection options ar
 
 instances
 ---------
-Checks and eventually downloads the instances for the experiments.
-It supports the following actions:
 
-:install: downloads all the missing instances if they are taken from a public repository.
-   With the argument ``--overwrite`` it will also download the available instances and
-   overwrite them.
-:list: lists all the instances found in the experiments.yml file.
-   Available instances are shown in green, unavailable instances in red.
-:process: caches information about instances.
-:run-transform: manually runs a transformation on instance files.
+The instance command can check the availability, and install instances. It
+supports the following flags:
+
+:install:         Installs missing instances. This can also trigger a download if an
+                  instance resource is configured accordingly. With the argument
+                  ``--overwrite``, this command will re-install all instances and
+                  overwrite existing ones.
+
+:list:            Lists all defined instances. Available instances are shown in green,
+                  unavailable instances in red.
+
+:process:         Caches information about instances.
+
+:run-transform:   Manually runs the defined transformation on instance files.
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -110,8 +110,8 @@ which can be specified as an additional argument. Supported selection options ar
 instances
 ---------
 
-The instance command can check the availability, and install instances. It
-supports the following flags:
+The instance command can check the availability of instances, and install
+instances. It supports the following flags:
 
 :install:         Installs missing instances. This can also trigger a download if an
                   instance resource is configured accordingly. With the argument

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -50,13 +50,13 @@ It further supports the following additional arguments:
 :--delete-source: Deletes the source directory when purging.
 :--install:       Installs the build files.
 :--purge:         Deletes all related build files.
-:--recheckout:    Deletes the cloned git repository, re-clones, regenerates,
-                  reconfigures, re-compiles, and reinstalls it.
-:--recompile:     Re-compiles and reinstall the build.
-:--reconfigure:   Re-configures the build.
-:--regenerate:    Re-generates the build.
-:--reinstall:     Re-installs the build.
-:--reregenerate:  Re-generates, re-configures, re-compiles, and reinstalls the build.
+:--recheckout:    Deletes the cloned git repository, reclones, regenerates,
+                  reconfigures, recompiles, and reinstalls it.
+:--recompile:     Recompiles and reinstall the build.
+:--reconfigure:   Reconfigures the build.
+:--regenerate:    Regenerates the build.
+:--reinstall:     Reinstalls the build.
+:--reregenerate:  Regenerates, reconfigures, recompiles, and reinstalls the build.
 
 The ``--checkout``, ``--recheckout`` and ``--purge`` arguments further require the ``-f`` argument to confirm
 their actions.
@@ -68,18 +68,18 @@ Responsible to check, execute and remove experiments. The experiments command
 accepts the following actions flags:
 
 :info:   Displays all related instances, instance sets, variant axes and variants
-         of experiments on the command-line.
+         of experiments on the command line.
 
 :list:   Lists all the experiments. Executed experiments are shown in green,
          failed ones are shown in red, running ones in yellow, and the non
-         executed ones in the default command-line color. With the argument
-         ``--detailed`` it will show every single run. With ``--compact`` all
+         executed ones in the default command line color. With the argument
+         ``--detailed`` it will show every single run. With ``--compact``, all
          runs with the same experiment will be grouped together. The ``--full``
          option forces simexpal to display the full experiment name.
 
 :launch: Launches all the non executed experiments.
 
-:print:  Displays all experimental output, including error outputs, on the command-line.
+:print:  Displays all experimental output, including error outputs, on the command line.
 
 :purge:  Deletes the experimental data. To confirm this action it needs the ``-f`` argument.
 
@@ -95,9 +95,9 @@ which can be specified as an additional argument. Supported selection options ar
 :--run <r>:                Selects the single run given as
                            ``<experiment_display_name>/<instance>``, where
                            ``<experiment_display_name>`` is the name of the
-                           experiment as displayed on the command-line and
+                           experiment as displayed on the command line and
                            ``<instance>`` is the instance name as displayed on
-                           the command-line.
+                           the command line.
 :--experiment <e>:         Selects the experiment named *e*.
 :--failed:                 Selects all the failed experiments.
 :--instance <i>:           Selects all experiments with the instance named *i*.
@@ -115,7 +115,7 @@ supports the following flags:
 
 :install:         Installs missing instances. This can also trigger a download if an
                   instance resource is configured accordingly. With the argument
-                  ``--overwrite``, this command will re-install all instances and
+                  ``--overwrite``, this command will reinstall all instances and
                   overwrite existing ones.
 
 :list:            Lists all defined instances. Available instances are shown in green,
@@ -128,7 +128,7 @@ supports the following flags:
 queue
 -----
 
-Triggers actions, or prints information concerning the configured experiment
+Triggers actions or prints information concerning the configured experiment
 launcher and its queue.
 
 :daemon:       Prints info on the running daemon.

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -61,22 +61,28 @@ their actions.
 
 experiments
 -----------
-Responsible to check, execute and remove experiments.
-It supports the following actions:
 
-:info: displays all related instances, instance sets, variant axes and variants of experiments
-   on the command-line.
-:list: lists all the experiments.
-   Executed experiments are shown in green, failed ones are shown in red, running ones in
-   yellow, and the non executed ones in the default command-line color. With the argument
-   ``--detailed`` it will show every single run. With ``--compact`` all runs with the same
-   experiment will be grouped together. The ``--full`` option forces simexpal to display the
-   full experiment name.
-:launch: launches all the non executed experiments.
-:print: displays all experimental output, including error outputs, on the command-line.
-:purge: deletes the experimental data. To confirm this action it needs the ``-f`` argument.
-:kill: terminates jobs submitted to or started by Slurm. To confirm this action it needs
-    the ``-f`` argument.
+Responsible to check, execute and remove experiments. The experiments command
+accepts the following actions flags:
+
+:info    Displays all related instances, instance sets, variant axes and variants
+         of experiments on the command-line.
+
+:list    Lists all the experiments. Executed experiments are shown in green,
+         failed ones are shown in red, running ones in yellow, and the non
+         executed ones in the default command-line color. With the argument
+         ``--detailed`` it will show every single run. With ``--compact`` all
+         runs with the same experiment will be grouped together. The ``--full``
+         option forces simexpal to display the full experiment name.
+
+:launch  Launches all the non executed experiments.
+
+:print   Displays all experimental output, including error outputs, on the command-line.
+
+:purge   Deletes the experimental data. To confirm this action it needs the ``-f`` argument.
+
+:kill    Terminates jobs submitted to or started by Slurm. To confirm this
+         action it needs the ``-f`` argument.
 
 All the above actions can be applied to a subset of experiments according to a `selection option`,
 which can be specified as an additional argument. Supported selection options are:

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -20,6 +20,7 @@ where the ``experiments.yml`` file is located.
 
 builds
 ------
+
 Responsible to download Git repositories and install executables.
 It supports the following actions:
 
@@ -33,6 +34,7 @@ not specifying the ``--revisions`` argument will lead to the selection of every 
 
 develop
 -------
+
 Responsible to download Git repositories and install executables. It also allows you to redo arbitrary
 build steps after changing local Git files to take over the local changes.
 
@@ -65,23 +67,23 @@ experiments
 Responsible to check, execute and remove experiments. The experiments command
 accepts the following actions flags:
 
-:info    Displays all related instances, instance sets, variant axes and variants
+:info:   Displays all related instances, instance sets, variant axes and variants
          of experiments on the command-line.
 
-:list    Lists all the experiments. Executed experiments are shown in green,
+:list:   Lists all the experiments. Executed experiments are shown in green,
          failed ones are shown in red, running ones in yellow, and the non
          executed ones in the default command-line color. With the argument
          ``--detailed`` it will show every single run. With ``--compact`` all
          runs with the same experiment will be grouped together. The ``--full``
          option forces simexpal to display the full experiment name.
 
-:launch  Launches all the non executed experiments.
+:launch: Launches all the non executed experiments.
 
-:print   Displays all experimental output, including error outputs, on the command-line.
+:print:  Displays all experimental output, including error outputs, on the command-line.
 
-:purge   Deletes the experimental data. To confirm this action it needs the ``-f`` argument.
+:purge:  Deletes the experimental data. To confirm this action it needs the ``-f`` argument.
 
-:kill    Terminates jobs submitted to or started by Slurm. To confirm this
+:kill:   Terminates jobs submitted to or started by Slurm. To confirm this
          action it needs the ``-f`` argument.
 
 All the above actions can be applied to a subset of experiments according to a `selection option`,

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -121,7 +121,10 @@ instances. It supports the following flags:
 :list:            Lists all defined instances. Available instances are shown in green,
                   unavailable instances in red.
 
-:process:         Caches information about instances.
+:process:         This command will read in all available instances, read the
+                  count of vertices and edges per file and print it to a file
+                  with the same name as the instance with extension `.info`.
+                  This command is therefore specific for graph files.
 
 :run-transform:   Manually runs the defined transformation on instance files.
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -92,7 +92,7 @@ which can be specified as an additional argument. Supported selection options ar
 :--all:                    Selects all the experiments.
 :--axes [axes...]:         Selects all experiments with the variant axes from
                            the space separated list of *axes*.
-:--run <r>:                Selects the single run given as
+:--run <r>:                Selects the single run *r* given as
                            ``<experiment_display_name>/<instance>``, where
                            ``<experiment_display_name>`` is the name of the
                            experiment as displayed on the command line and
@@ -103,7 +103,7 @@ which can be specified as an additional argument. Supported selection options ar
 :--instance <i>:           Selects all experiments with the instance named *i*.
 :--instset <i>:            Selects all experiments with the instance set named *i*.
 :--unfinished:             Selects all the unfinished experiments.
-:--revision <i>:           Selects all experiments with the revision named *r*.
+:--revision <r>:           Selects all experiments with the revision named *r*.
 :--variants [variants...]: Selects all experiments with the variants from the
                            space separated list of variants.
 

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -21,8 +21,8 @@ where the ``experiments.yml`` file is located.
 builds
 ------
 
-Responsible to download Git repositories and install executables.
-It supports the following actions:
+Used to download Git repositories and install executables. It supports the
+following actions:
 
 :make: downloads a Git repository and executes all build commands.
 :purge: deletes all related build files. To confirm this action it needs the ``-f`` argument.
@@ -35,8 +35,9 @@ not specifying the ``--revisions`` argument will lead to the selection of every 
 develop
 -------
 
-Responsible to download Git repositories and install executables. It also allows you to redo arbitrary
-build steps after changing local Git files to take over the local changes.
+Used to download Git repositories and install executables. It also allows you to
+redo arbitrary build steps after changing local Git files to take over the local
+changes.
 
 The ``develop`` action can be applied to a subset of builds according to the ``--revisions`` and
 positional ``builds`` argument (analogously to how it works for the :ref:`simex builds <cli_builds>`
@@ -64,8 +65,8 @@ their actions.
 experiments
 -----------
 
-Responsible to check, execute and remove experiments. The experiments command
-accepts the following actions flags:
+Used to check, execute and remove experiments. The experiments command accepts
+the following actions flags:
 
 :info:   Displays all related instances, instance sets, variant axes and variants
          of experiments on the command line.

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -120,3 +120,18 @@ supports the following flags:
 
 :run-transform:   Manually runs the defined transformation on instance files.
 
+queue
+-----
+
+Triggers actions, or prints information concerning the configured experiment
+launcher and its queue.
+
+:daemon:       Prints info on the running daemon.
+
+:stop:         Stops the elements in the queue from being processed.
+
+:interactive:  Provides an interactive shell with the queue.
+
+:kill:         Kills the queue process.
+
+:show:         Prints the queued experiments using the queue daemon.

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -3,7 +3,8 @@
 Command-line Reference
 ======================
 
-Simexpal instructions are written as:
+simexpal instructions are written as:
+
 ::
 
    simex <instruction> [action] [selection option] [args...]


### PR DESCRIPTION
This PR addresses issue #56 

Most of the changes are minimal, and only represent revisions of already present documentation. Only the `queue` documentation is new.

The rendering of the documentation is available under: https://simexpal-fork.readthedocs.io/en/simexpal_doc_56/command_line_reference.html