### PR TITLE
Develop revisions

### DIFF
--- a/scripts/simex
+++ b/scripts/simex
@@ -236,10 +236,12 @@ def select_phases_from_cli(args):
 
 phase_selection_parser = argparse.ArgumentParser(add_help=False)
 phase_selection_mechanism = phase_selection_parser.add_mutually_exclusive_group()
-phase_selection_mechanism.add_argument('--recheckout', action='store_true',
+phase_selection_mechanism.add_argument('--reclone', action='store_true',
 			help='Delete local build git repository, reclone, regenerate, reconfigure, recompile and reinstall it')
+phase_selection_mechanism.add_argument('--recheckout', action='store_true',
+			help='Checkout local build git repository, regenerate, reconfigure, recompile and reinstall it')
 phase_selection_mechanism.add_argument('--checkout', action='store_true',
-			help='Delete local git repository for build and (re-)clone it')
+			help='Checkout local build git repository')
 phase_selection_mechanism.add_argument('--reregenerate', action='store_true',
 			help='Regenerate, reconfigure, recompile and reinstall build')
 phase_selection_mechanism.add_argument('--regenerate', action='store_true',
@@ -351,7 +353,7 @@ def do_builds_make(args):
 	ordered_revisions, sel = select_builds_from_cli(args, cfg.all_non_dev_builds())
 	for revision in ordered_revisions:
 
-		simexpal.build.make_builds(args, cfg, revision,
+		simexpal.build.make_builds(cfg, revision,
 				[build.info for build in sel[revision]], [], [])
 
 builds_make_parser = builds_subcmds.add_parser('make', parents=[build_selection_parser])
@@ -375,7 +377,7 @@ def do_builds_remake(args):
 	ordered_revisions, sel = select_builds_from_cli(args, cfg.all_non_dev_builds())
 	for revision in ordered_revisions:
 
-		simexpal.build.make_builds(args, cfg, revision,
+		simexpal.build.make_builds(cfg, revision,
 				[build.info for build in sel[revision]], [build.name for build in sel[revision]], wanted_phases)
 
 builds_remake_parser = builds_subcmds.add_parser('remake', parents=[build_selection_parser])
@@ -385,6 +387,10 @@ builds_remake_parser.set_defaults(cmd=do_builds_remake)
 
 def do_develop(args):
 	cfg = extl.base.config_for_dir()
+
+	# If user wants to reclone, execute all phases (but do clone instead of checkout)
+	if args.reclone:
+		args.recheckout = True
 
 	wanted_phases = select_phases_from_cli(args)
 	if not wanted_phases:
@@ -397,8 +403,9 @@ def do_develop(args):
 		ordered_revisions, sel = select_builds_from_cli(args, cfg.all_dev_builds())
 		for revision in ordered_revisions:
 
-			simexpal.build.make_builds(args, cfg, revision,
-					[build.info for build in sel[revision]], [build.name for build in sel[revision]], wanted_phases)
+			simexpal.build.make_builds(cfg, revision,
+					[build.info for build in sel[revision]], [build.name for build in sel[revision]], wanted_phases,
+					args.reclone)
 
 dev_builds_parser = main_subcmds.add_parser('develop', help='Build local programs',
 		aliases=['d'], parents=[phase_selection_parser, build_selection_parser])

--- a/scripts/simex
+++ b/scripts/simex
@@ -213,19 +213,9 @@ def select_phases_from_cli(args):
 		return [phase for phase in simexpal.build.Phase if phase >= start_phase]
 
 	if args.recheckout:
-		if not args.f:
-			print("This would delete the local git repository for the build and reclone it (does not apply to"
-					" VCS-less dev-builds). Confirm this action by using the '-f' flag.")
-			return []
-		else:
-			return subsequent_phases(simexpal.build.Phase.CHECKOUT)
+		return subsequent_phases(simexpal.build.Phase.CHECKOUT)
 	elif args.checkout:
-		if not args.f:
-			print("This would delete the local git repository for the build and reclone it (does not apply to"
-					" VCS-less dev-builds). Confirm this action by using the '-f' flag.")
-			return []
-		else:
-			return [simexpal.build.Phase.CHECKOUT]
+		return [simexpal.build.Phase.CHECKOUT]
 	elif args.reregenerate:
 		return subsequent_phases(simexpal.build.Phase.REGENERATE)
 	elif args.regenerate:
@@ -361,7 +351,7 @@ def do_builds_make(args):
 	ordered_revisions, sel = select_builds_from_cli(args, cfg.all_non_dev_builds())
 	for revision in ordered_revisions:
 
-		simexpal.build.make_builds(cfg, revision,
+		simexpal.build.make_builds(args, cfg, revision,
 				[build.info for build in sel[revision]], [], [])
 
 builds_make_parser = builds_subcmds.add_parser('make', parents=[build_selection_parser])
@@ -385,7 +375,7 @@ def do_builds_remake(args):
 	ordered_revisions, sel = select_builds_from_cli(args, cfg.all_non_dev_builds())
 	for revision in ordered_revisions:
 
-		simexpal.build.make_builds(cfg, revision,
+		simexpal.build.make_builds(args, cfg, revision,
 				[build.info for build in sel[revision]], [build.name for build in sel[revision]], wanted_phases)
 
 builds_remake_parser = builds_subcmds.add_parser('remake', parents=[build_selection_parser])
@@ -407,7 +397,7 @@ def do_develop(args):
 		ordered_revisions, sel = select_builds_from_cli(args, cfg.all_dev_builds())
 		for revision in ordered_revisions:
 
-			simexpal.build.make_builds(cfg, revision,
+			simexpal.build.make_builds(args, cfg, revision,
 					[build.info for build in sel[revision]], [build.name for build in sel[revision]], wanted_phases)
 
 dev_builds_parser = main_subcmds.add_parser('develop', help='Build local programs',

--- a/simexpal/build.py
+++ b/simexpal/build.py
@@ -5,13 +5,13 @@ import subprocess
 
 from . import util
 
-def make_builds(cfg, revision, infos, wanted_builds, wanted_phases):
+def make_builds(args, cfg, revision, infos, wanted_builds, wanted_phases):
 	order = compute_order(cfg, infos)
 
 	print("simexpal: Making builds {} @ {}".format(', '.join([info.name for info in order]),
 			revision.name))
 	for info in order:
-		make_build_in_order(cfg, cfg.get_build(info.name, revision), wanted_builds, wanted_phases)
+		make_build_in_order(args, cfg, cfg.get_build(info.name, revision), wanted_builds, wanted_phases)
 
 def compute_order(cfg, desired):
 	class State(Enum):
@@ -65,7 +65,7 @@ class Phase(IntEnum):
 	COMPILE = 4
 	INSTALL = 5
 
-def make_build_in_order(cfg, build, wanted_builds, wanted_phases):
+def make_build_in_order(args, cfg, build, wanted_builds, wanted_phases):
 	if not build.revision.is_dev_build:
 		util.try_mkdir(cfg.basedir + '/builds/')
 		checkout_dir = build.clone_dir
@@ -264,12 +264,27 @@ def make_build_in_order(cfg, build, wanted_builds, wanted_phases):
 						build.clone_dir,
 						generic_tag])
 			else:
-				# Recreate the source directory
-				util.try_rmtree(build.source_dir)
-				util.try_mkdir(build.source_dir)
+				branch = build.revision.version_for_build(build.name)
+				if os.path.isdir(build.source_dir):
+					# Repository already cloned, check for local changes
+					status = subprocess.check_output(['git', 'status', '--porcelain'], cwd=build.source_dir)
+					if len(status) == 0:
+						# If there are no local changes, checkout the given branch
+						subprocess.check_call(['git', 'checkout', branch], cwd=build.source_dir)
+					else:
+						# If there are local changes, discard them
+						if not args.f:
+							print("This will discard the local changes for the build and checkout to the latest commit of the branch."
+			 						" Confirm this action by using the '-f' flag.")
+							return
+						else:
+							subprocess.check_call(['git', 'checkout', branch], cwd=build.source_dir)
+				else:
+					# Clone the branch of the repository into the build.source_dir
+					util.try_mkdir(build.source_dir)
 
-				# Clone the git repository into the build.source_dir
-				subprocess.check_call(['git', 'clone', build.info.git_repo, build.source_dir])
+					subprocess.check_call(['git', 'clone', build.info.git_repo, build.source_dir])
+					subprocess.check_call(['git', 'checkout', branch], cwd=build.source_dir)
 
 			util.touch(os.path.join(checkout_dir, 'checkedout.simexpal'))
 

--- a/tests/builds/test_builds.py
+++ b/tests/builds/test_builds.py
@@ -12,7 +12,8 @@ def test_simex_d_vcs_less():
     revision = cfg.get_revision('main')
     vcs_less_build = cfg.get_build('vcs-less', revision)
 
-    build.make_builds(cfg, revision, [vcs_less_build.info], ['vcs-less'], [build.Phase.INSTALL])
+    # Passing None for args is fine since it's properties are not used for vcs-less builds
+    build.make_builds(None, cfg, revision, [vcs_less_build.info], ['vcs-less'], [build.Phase.INSTALL])
 
     def check_files_in_dir(files, dir):
         for file_name in files:

--- a/tests/builds/test_builds.py
+++ b/tests/builds/test_builds.py
@@ -12,7 +12,6 @@ def test_simex_d_vcs_less():
     revision = cfg.get_revision('main')
     vcs_less_build = cfg.get_build('vcs-less', revision)
 
-    # Passing None for args is fine since it's properties are not used for vcs-less builds
     build.make_builds(cfg, revision, [vcs_less_build.info], ['vcs-less'], [build.Phase.INSTALL])
 
     def check_files_in_dir(files, dir):

--- a/tests/builds/test_builds.py
+++ b/tests/builds/test_builds.py
@@ -13,7 +13,7 @@ def test_simex_d_vcs_less():
     vcs_less_build = cfg.get_build('vcs-less', revision)
 
     # Passing None for args is fine since it's properties are not used for vcs-less builds
-    build.make_builds(None, cfg, revision, [vcs_less_build.info], ['vcs-less'], [build.Phase.INSTALL])
+    build.make_builds(cfg, revision, [vcs_less_build.info], ['vcs-less'], [build.Phase.INSTALL])
 
     def check_files_in_dir(files, dir):
         for file_name in files:


### PR DESCRIPTION
Addresses #142. The develop revisions checkout logic is now as follows:

1. if the repository has not been cloned yet:
    1. run `git clone <repo_url>`
    2. run `git checkout <branch_name>`, where `branch_name` is the `build_version` specified in the `experiments.yml`
2. if the repository has already been cloned:
    1. if there are local changes using (checked using `git status --porcelain`):
        1. if the force/confirmation flag (`-f`) has been set: checkout given branch by running `git checkout <branch_name>`
        2. if the force/confirmation flag has not been set: warn the user of local changes and refer to the force/confirmation flag
    2. if there are no local changes: checkout given branch by running `git checkout <branch_name>`