### PR TITLE
Revert "Merge pull request #161 from nizomovs/develop-revisions"

### DIFF
--- a/scripts/simex
+++ b/scripts/simex
@@ -213,9 +213,19 @@ def select_phases_from_cli(args):
 		return [phase for phase in simexpal.build.Phase if phase >= start_phase]
 
 	if args.recheckout:
-		return subsequent_phases(simexpal.build.Phase.CHECKOUT)
+		if not args.f:
+			print("This would delete the local git repository for the build and reclone it (does not apply to"
+					" VCS-less dev-builds). Confirm this action by using the '-f' flag.")
+			return []
+		else:
+			return subsequent_phases(simexpal.build.Phase.CHECKOUT)
 	elif args.checkout:
-		return [simexpal.build.Phase.CHECKOUT]
+		if not args.f:
+			print("This would delete the local git repository for the build and reclone it (does not apply to"
+					" VCS-less dev-builds). Confirm this action by using the '-f' flag.")
+			return []
+		else:
+			return [simexpal.build.Phase.CHECKOUT]
 	elif args.reregenerate:
 		return subsequent_phases(simexpal.build.Phase.REGENERATE)
 	elif args.regenerate:
@@ -236,12 +246,10 @@ def select_phases_from_cli(args):
 
 phase_selection_parser = argparse.ArgumentParser(add_help=False)
 phase_selection_mechanism = phase_selection_parser.add_mutually_exclusive_group()
-phase_selection_mechanism.add_argument('--reclone', action='store_true',
-			help='Delete local build git repository, reclone, regenerate, reconfigure, recompile and reinstall it')
 phase_selection_mechanism.add_argument('--recheckout', action='store_true',
-			help='Checkout local build git repository, regenerate, reconfigure, recompile and reinstall it')
+			help='Delete local build git repository, reclone, regenerate, reconfigure, recompile and reinstall it')
 phase_selection_mechanism.add_argument('--checkout', action='store_true',
-			help='Checkout local build git repository')
+			help='Delete local git repository for build and (re-)clone it')
 phase_selection_mechanism.add_argument('--reregenerate', action='store_true',
 			help='Regenerate, reconfigure, recompile and reinstall build')
 phase_selection_mechanism.add_argument('--regenerate', action='store_true',
@@ -388,10 +396,6 @@ builds_remake_parser.set_defaults(cmd=do_builds_remake)
 def do_develop(args):
 	cfg = extl.base.config_for_dir()
 
-	# If user wants to reclone, execute all phases (but do clone instead of checkout)
-	if args.reclone:
-		args.recheckout = True
-
 	wanted_phases = select_phases_from_cli(args)
 	if not wanted_phases:
 		return
@@ -404,8 +408,7 @@ def do_develop(args):
 		for revision in ordered_revisions:
 
 			simexpal.build.make_builds(cfg, revision,
-					[build.info for build in sel[revision]], [build.name for build in sel[revision]], wanted_phases,
-					args.reclone)
+					[build.info for build in sel[revision]], [build.name for build in sel[revision]], wanted_phases)
 
 dev_builds_parser = main_subcmds.add_parser('develop', help='Build local programs',
 		aliases=['d'], parents=[phase_selection_parser, build_selection_parser])

--- a/simexpal/build.py
+++ b/simexpal/build.py
@@ -5,13 +5,13 @@ import subprocess
 
 from . import util
 
-def make_builds(cfg, revision, infos, wanted_builds, wanted_phases, reclone=False):
+def make_builds(cfg, revision, infos, wanted_builds, wanted_phases):
 	order = compute_order(cfg, infos)
 
 	print("simexpal: Making builds {} @ {}".format(', '.join([info.name for info in order]),
 			revision.name))
 	for info in order:
-		make_build_in_order(cfg, cfg.get_build(info.name, revision), wanted_builds, wanted_phases, reclone)
+		make_build_in_order(cfg, cfg.get_build(info.name, revision), wanted_builds, wanted_phases)
 
 def compute_order(cfg, desired):
 	class State(Enum):
@@ -65,7 +65,7 @@ class Phase(IntEnum):
 	COMPILE = 4
 	INSTALL = 5
 
-def make_build_in_order(cfg, build, wanted_builds, wanted_phases, reclone):
+def make_build_in_order(cfg, build, wanted_builds, wanted_phases):
 	if not build.revision.is_dev_build:
 		util.try_mkdir(cfg.basedir + '/builds/')
 		checkout_dir = build.clone_dir
@@ -180,25 +180,6 @@ def make_build_in_order(cfg, build, wanted_builds, wanted_phases, reclone):
 	def log_phase(step):
 		print("simexpal: Running {}-phase for build {}".format(step, build.name))
 
-	def do_develop_checkout(build, reclone):
-		branch = build.revision.version_for_build(build.name)
-		if os.path.isdir(build.source_dir) and not reclone:
-			# Repository already cloned, check for local changes
-			status = subprocess.check_output(['git', 'status', '--porcelain'], cwd=build.source_dir)
-			if len(status) != 0:
-				print("There are local changes that have not yet been commited and pushed. Please clean them up before proceeding.")
-				return
-
-			subprocess.check_call(['git', 'checkout', branch], cwd=build.source_dir)
-			subprocess.check_call(['git', 'pull'], cwd=build.source_dir)
-		else:
-			# Clone the branch of the repository into the build.source_dir
-			util.try_rmtree(build.source_dir)
-			util.try_mkdir(build.source_dir)
-
-			subprocess.check_call(['git', 'clone', build.info.git_repo, build.source_dir])
-			subprocess.check_call(['git', 'checkout', branch], cwd=build.source_dir)
-
 	did_work = False
 
 	def do_step(step_yml, default_workdir=None):
@@ -283,7 +264,12 @@ def make_build_in_order(cfg, build, wanted_builds, wanted_phases, reclone):
 						build.clone_dir,
 						generic_tag])
 			else:
-				do_develop_checkout(build, reclone)
+				# Recreate the source directory
+				util.try_rmtree(build.source_dir)
+				util.try_mkdir(build.source_dir)
+
+				# Clone the git repository into the build.source_dir
+				subprocess.check_call(['git', 'clone', build.info.git_repo, build.source_dir])
 
 			util.touch(os.path.join(checkout_dir, 'checkedout.simexpal'))
 


### PR DESCRIPTION
This reverts commit 6dfbb2eacfa81606cadf3272c1668ae8b89c26ff, reversing changes made to 1a01ae37ebce571aaad047766fb7fee950e8644d.

Reasoning: the feature did fail a few tests and we need to rethink how simexpal writes cache files. Currently, simexpal write cache files also to git repositories. This has been a problem ever since I worked with it, and in this case we have the problem that a clean state in the build folder can not be the case as soon as those cache files are present. Therefore, we must revert this merge and make further changes to simexpal to finish the work on the develop revisions feature #142 