### PR TITLE
Add INSTANCE_FILENAME @-Variable

### DIFF
--- a/simexpal/launch/common.py
+++ b/simexpal/launch/common.py
@@ -353,9 +353,7 @@ def invoke_run(manifest):
 		elif p.startswith('INSTANCE:'):
 			return get_qualified_filename(p.split(':')[1])
 		elif p == 'INSTANCE_FILENAME':
-			if manifest.instance_is_filess:
-				raise RuntimeError(f"The instance '{manifest.instance}' is fileless. Did you forget to remove the @INSTANCE_FILENAME@ variable in the argument list of the experiment?")
-
+			# @INSTANCE_FILENAME@ is only the instance name and hence can still be used for fileless instances
 			return manifest.instance_name
 		elif p == 'REPETITION':
 			return str(manifest.repetition)

--- a/simexpal/launch/common.py
+++ b/simexpal/launch/common.py
@@ -352,6 +352,11 @@ def invoke_run(manifest):
 			return manifest.instance_dir + '/' + manifest.instance_name
 		elif p.startswith('INSTANCE:'):
 			return get_qualified_filename(p.split(':')[1])
+		elif p == 'INSTANCE_FILENAME':
+			if manifest.instance_is_filess:
+				raise RuntimeError(f"The instance '{manifest.instance}' is fileless. Did you forget to remove the @INSTANCE_FILENAME@ variable in the argument list of the experiment?")
+
+			return manifest.instance_name
 		elif p == 'REPETITION':
 			return str(manifest.repetition)
 		elif p == 'OUTPUT':

--- a/tests/instances/experiments_ymls/fileless/instance.yml
+++ b/tests/instances/experiments_ymls/fileless/instance.yml
@@ -1,0 +1,11 @@
+# This file contains a fileless instance and an experiment that tries using the @-variable 'INSTANCE'.
+# Since that property is the full path to the instance file, it can not be used for fileless instances.
+instances:
+  - repo: local
+    items:
+      - name: fileless-instance
+        files: []
+
+experiments:
+  - name: empty-experiment
+    args: ['@INSTANCE@']

--- a/tests/instances/experiments_ymls/fileless/instance_filename.yml
+++ b/tests/instances/experiments_ymls/fileless/instance_filename.yml
@@ -1,0 +1,11 @@
+# This file contains a fileless instance and an experiment that uses the @-variable 'INSTANCE_FILENAME'.
+instances:
+  - repo: local
+    items:
+      - name: fileless-instance
+        files: []
+
+experiments:
+  - name: empty-experiment
+    args: ['echo', '@INSTANCE_FILENAME@']
+    stdout: out

--- a/tests/instances/test_fileless.py
+++ b/tests/instances/test_fileless.py
@@ -8,14 +8,14 @@ from simexpal.launch import common
 
 file_dir = os.path.abspath(os.path.dirname(__file__))
 
-valid_experiments_ymls = ['experiments_ymls/fileless/instance_filename.yml'
+valid_experiments_ymls = [('experiments_ymls/fileless/instance_filename.yml', ['fileless-instance'])
                           ]
 
 invalid_experiments_ymls = [('experiments_ymls/fileless/instance.yml', "The instance 'fileless-instance' is fileless. Did you forget to remove the @INSTANCE@ variable in the argument list of the experiment?")
                             ]
 
-@pytest.mark.parametrize('rel_yml_path', valid_experiments_ymls)
-def test_valid_fileless_experiments_yml(rel_yml_path):
+@pytest.mark.parametrize('rel_yml_path, expected_output', valid_experiments_ymls)
+def test_valid_fileless_experiments_yml(rel_yml_path, expected_output):
     rel_yml_dir = os.path.dirname(rel_yml_path)
     yml_dir = os.path.join(file_dir, rel_yml_dir)
     filename = os.path.basename(rel_yml_path)
@@ -31,7 +31,9 @@ def test_valid_fileless_experiments_yml(rel_yml_path):
         manifest = common.compile_manifest(run)
         common.invoke_run(manifest)
 
-        os.path.getsize(run.output_file_path('out'))
+        with open(run.output_file_path('out'), 'r') as output:
+            actual_output = output.read().splitlines()
+            assert expected_output == actual_output
 
 @pytest.mark.parametrize('rel_yml_path, error_message', invalid_experiments_ymls)
 def test_invalid_fileless_experiments_yml(rel_yml_path, error_message):

--- a/tests/instances/test_fileless.py
+++ b/tests/instances/test_fileless.py
@@ -1,0 +1,29 @@
+
+import os
+import pytest
+
+from simexpal import util
+from simexpal.base import Config
+from simexpal.launch import common
+
+file_dir = os.path.abspath(os.path.dirname(__file__))
+
+invalid_experiments_ymls = [('experiments_ymls/fileless/instance.yml', "The instance 'fileless-instance' is fileless. Did you forget to remove the @INSTANCE@ variable in the argument list of the experiment?")
+                            ]
+
+@pytest.mark.parametrize('rel_yml_path, error_message', invalid_experiments_ymls)
+def test_invalid_fileless_experiments_yml(rel_yml_path, error_message):
+    rel_yml_dir = os.path.dirname(rel_yml_path)
+    yml_dir = os.path.join(file_dir, rel_yml_dir)
+    filename = os.path.basename(rel_yml_path)
+
+    yml = util.validate_setup_file(yml_dir, filename, 'experiments.json')
+    cfg = Config(yml_dir, yml)
+
+    for run in cfg.discover_all_runs():
+        manifest = common.compile_manifest(run)
+
+        with pytest.raises(RuntimeError) as error:
+            common.invoke_run(manifest)
+
+        assert error_message == str(error.value)

--- a/tests/instances/test_fileless.py
+++ b/tests/instances/test_fileless.py
@@ -21,6 +21,10 @@ def test_invalid_fileless_experiments_yml(rel_yml_path, error_message):
     cfg = Config(yml_dir, yml)
 
     for run in cfg.discover_all_runs():
+        if not common.lock_run(run):
+            return
+        common.create_run_file(run)
+
         manifest = common.compile_manifest(run)
 
         with pytest.raises(RuntimeError) as error:


### PR DESCRIPTION
The `INSTANCE_FILENAME` @-Variable was only usable for instance generators. However, it is useful in the `extra_args` member of experiments to i.e. allow using custom output directories in the output folder per instance.