### PR TITLE
refactor build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install ninja
+        run: |
+          python -m pip install ninja
       - name: Install simexpal
         run: |
           python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,12 @@ simexpal.egg-info/
 
 validation.cache
 
-examples/*/validation.cache
-examples/*/status.cache
+*.simex.cache
 examples/sorting_cpp/builds/*
 
 tests/builds/experiments_ymls/vcs_less/dev-builds/*
 tests/builds/experiments_ymls/vcs_less/develop/vcs-less@main/*
+tests/builds/experiments_ymls/build_examples/builds/*
+tests/builds/experiments_ymls/build_examples/dev-builds/*
+tests/builds/experiments_ymls/build_examples/develop/*
+tests/builds/experiments_ymls/build_examples/bin

--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -297,14 +297,14 @@ Below you can find the shortened directory structure of our
 `C++ example <https://github.com/hu-macsy/simexpal/tree/master/examples/sorting_cpp>`_ example. The
 repository directory has ``<build_name>`` as prefix and ``.repo`` as suffix. The clone, compilation and
 installation directory have ``<build_name>@<revision_name>`` as prefix and the first two have ``.clone``
-and ``.compile`` as suffix respectively. The installation directory does not have any suffix. The internal
-simexpal files have the suffix ``.simexpal``.
+and ``.compile`` as suffix respectively. The installation directory does not have any suffix. The internal 
+cache that memorizes the internal state is the ``.simex.cache`` file, which is found at the level of the 
+``experiments.yml`` file. 
 
 .. code-block:: bash
    :caption: Build directories for normal builds used by simexpal during the build process.
 
    /path/to/experiments.yml/directory
-   ├── CMakeLists.txt
    ├── builds
    │   ├── simexpal.repo                        # repository directory
    │   │   ├── internal simexpal
@@ -313,10 +313,7 @@ simexpal files have the suffix ``.simexpal``.
    │   ├── simexpal@main                        # installation/prefix directory
    │   │   ├── bin
    │   │   │   └── quicksort                    # our executable
-   │   │   └── installed.simexpal               # internal simexpal file
    │   ├── simexpal@main.clone                  # clone directory
-   │   │   ├── checkedout.simexpal              # internal simexpal file
-   │   │   ├── regenerated.simexpal             # internal simexpal file
    │   │   ├── project
    │   │   ├── ...
    │   │   └── files/directories
@@ -324,8 +321,8 @@ simexpal files have the suffix ``.simexpal``.
    │       ├── configuration and compilation
    │       ├── ...
    │       ├── files/directories
-   │       ├── compiled.simexpal                # internal simexpal file
-   │       └── configured.simexpal              # internal simexpal file
+   ├── .simex.cache                             # internal simexpal cache file
+   ├── CMakeLists.txt
    ├── experiments.yml
    └── quicksort.cpp
 
@@ -352,32 +349,28 @@ Below you can find the shortened directory structure of our
 (if ``recursive-clone`` was set to ``True``). The clone, compilation and installation directory have
 ``<build_name>@<revision_name>`` as prefix. Additionally, the compilation directory has ``.compile``
 as suffix. The clone directory is located in the ``/develop`` directory, whereas the compilation and
-installation directories are located in the ``/dev-builds`` directory. The internal simexpal files have
-the suffix ``.simexpal``.
+installation directories are located in the ``/dev-builds`` directory. The internal cache that memorizes
+the internal state is the ``.simex.cache`` file, which is found at the level of the ``experiments.yml`` file. 
 
 .. code-block:: bash
    :caption: Build directories for dev-builds used by simexpal during the build process.
 
    /path/to/experiments.yml/directory
-   ├── CMakeLists.txt
    ├── dev-builds
    │   ├── simexpal@main                        # installation/prefix directory
    │   │   ├── bin
    │   │   │   └── quicksort                    # our executable
-   │   │   └── installed.simexpal               # internal simexpal file
    │   └── simexpal@main.compile                # compilation directory
    │       ├── configuration and compilation
    │       ├── ...
    │       ├── files/directories
-   │       ├── compiled.simexpal                # internal simexpal file
-   │       └── configured.simexpal              # internal simexpal file
    ├── develop
    │   └── simexpal@main                        # clone directory
    │       ├── project
    │       ├── ...
    │       ├── files/directories
-   │       ├── checkedout.simexpal              # internal simexpal file
-   │       └── regenerated.simexpal             # internal simexpal file
+   ├── .simex.cache                             # internal simexpal cache file
+   ├── CMakeLists.txt
    ├── experiments.yml
    └── quicksort.cpp
 

--- a/scripts/simex
+++ b/scripts/simex
@@ -23,6 +23,7 @@ from simexpal.base import Status
 from simexpal.base import YmlLoader
 from itertools import zip_longest
 import yaml
+import json
 import warnings
 
 warnings.simplefilter(action='default', category=DeprecationWarning)  # do not ignore DeprecationWarnings

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -82,7 +82,7 @@ class Config:
 		self.basedir = basedir
 		self.yml = yml
 
-		self.status_cache_path = basedir + '/status.cache'
+		self.status_cache_path = basedir + util.SIMEX_CACHE
 		self.status_cache_dict = {}
 
 		self.slurm_queried = False
@@ -195,8 +195,8 @@ class Config:
 				self._exp_infos[exp_yml['name']] = ExperimentInfo(self, exp_yml)
 
 		try:
-			with open(self.status_cache_path, 'r') as f:
-				self.status_cache_dict = json.load(f)
+			with open(self.status_cache_path, 'r') as cachefile:
+				self.status_cache_dict = json.load(cachefile)["status"]
 		except FileNotFoundError:
 			pass
 
@@ -503,10 +503,11 @@ class Config:
 		return Status(self.queue_queried_jobs.get(jobid, Status.FAILED))
 
 	def writeback_status_cache(self):
-		fd, path = tempfile.mkstemp(dir=self.basedir)
-		with os.fdopen(fd, 'w') as tmp:
-			json.dump(self.status_cache_dict, tmp)
-		os.rename(path, self.status_cache_path)
+		with open(os.path.join(self.basedir, util.SIMEX_CACHE), 'r') as cachefile:
+			cache = json.load(cachefile)
+		cache["status"] = self.status_cache_dict
+		with open(os.path.join(self.basedir, util.SIMEX_CACHE), 'w') as cachefile:
+			json.dump(cache, cachefile)
 
 	# -----------------------------------------------------------------------------------
 	# Matrix expansion.
@@ -1011,24 +1012,25 @@ class Build:
 		rev = self._get_dev_build_suffix()
 		return os.path.join(self._cfg.basedir, 'develop', self.name + rev)
 
-	def is_checked_out(self):
-		if self.revision.is_dev_build:
-			return os.access(os.path.join(self.source_dir, 'checkedout.simexpal'), os.F_OK)
-		return os.access(os.path.join(self.clone_dir, 'checkedout.simexpal'), os.F_OK)
+	def is_checked_out(self, buildname):
+		with open(os.path.join(self._cfg.basedir, util.SIMEX_CACHE), 'r') as cachefile:
+			return json.load(cachefile)[buildname][util.CHECKOUT]
 
-	def is_regenerated(self):
-		if self.revision.is_dev_build:
-			return os.access(os.path.join(self.source_dir, 'regenerated.simexpal'), os.F_OK)
-		return os.access(os.path.join(self.clone_dir, 'regenerated.simexpal'), os.F_OK)
+	def is_regenerated(self, buildname):
+		with open(os.path.join(self._cfg.basedir, util.SIMEX_CACHE), 'r') as cachefile:
+			return json.load(cachefile)[buildname][util.REGENERATED]
+			
+	def is_configured(self, buildname):
+		with open(os.path.join(self._cfg.basedir, util.SIMEX_CACHE), 'r') as cachefile:
+			return json.load(cachefile)[buildname][util.CONFIGURED]
 
-	def is_configured(self):
-		return os.access(os.path.join(self.compile_dir, 'configured.simexpal'), os.F_OK)
+	def is_compiled(self, buildname):
+		with open(os.path.join(self._cfg.basedir, util.SIMEX_CACHE), 'r') as cachefile:
+			return json.load(cachefile)[buildname][util.COMPILED]
 
-	def is_compiled(self):
-		return os.access(os.path.join(self.compile_dir, 'compiled.simexpal'), os.F_OK)
-
-	def is_installed(self):
-		return os.access(os.path.join(self.prefix_dir, 'installed.simexpal'), os.F_OK)
+	def is_installed(self, buildname):
+		with open(os.path.join(self._cfg.basedir, util.SIMEX_CACHE), 'r') as cachefile:
+			return json.load(cachefile)[buildname][util.INSTALLED]
 
 	def purge(self, delete_source=False):
 		if not self.revision.is_dev_build:
@@ -1502,8 +1504,22 @@ class Run:
 			raise RuntimeError("The experiment '{}' with instance '{}' has not been started yet".format(
 				self.experiment.display_name, self.instance.shortname))
 
+def init_cache_for_basedir(basedir):
+	if not os.path.isfile(os.path.join(basedir,util.SIMEX_CACHE)):
+		with open(os.path.join(basedir,util.SIMEX_CACHE), "x") as cachefile:
+			json.dump({"status": {}, "validation": {}}, cachefile) 
+
+def init_cache_entry_for_dir(basedir, buildname):
+	assert os.path.isfile(os.path.join(basedir, util.SIMEX_CACHE))
+	with open(os.path.join(basedir, util.SIMEX_CACHE), 'r') as cachefile:
+		cache = json.load(cachefile)
+	cache[buildname] = {util.CHECKOUT: False, util.REGENERATED: False, util.CONFIGURED: False, util.COMPILED: False, util.INSTALLED: False}
+	with open(os.path.join(basedir, util.SIMEX_CACHE), 'w') as cachefile:
+		json.dump(cache, cachefile)
+
 def config_for_dir(basedir=None):
 	if basedir is None:
 		basedir = '.'
+	init_cache_for_basedir(basedir)
 	yml = util.validate_setup_file(basedir, 'experiments.yml', 'experiments.json')
 	return Config(os.path.abspath(basedir), yml)

--- a/simexpal/util.py
+++ b/simexpal/util.py
@@ -8,6 +8,14 @@ import yaml
 import json
 import tempfile
 
+### CONSTANTS ###
+INSTALLED = "installation_done"
+COMPILED = "compilation_done"
+CONFIGURED = "configuration_done"
+REGENERATED = "regeneration_done"
+CHECKOUT = "checkout_done"
+
+SIMEX_CACHE = "./.simex.cache"
 
 def expand_at_params(s, fn, listfn=None):
 	def subfn(m):
@@ -126,8 +134,8 @@ def validate_setup_file(basedir, setup_file, setup_file_schema_name):
 
 	validation_cache_dict = {}
 	try:
-		with open(os.path.join(basedir, 'validation.cache'), 'r') as f:
-			validation_cache_dict = json.load(f)
+		with open(os.path.join(basedir, SIMEX_CACHE), 'r') as cachefile:
+			validation_cache_dict = json.load(cachefile)["validation"]
 	except FileNotFoundError:
 		pass
 
@@ -181,10 +189,12 @@ def validate_setup_file(basedir, setup_file, setup_file_schema_name):
 			do_exit = True
 
 	if writeback_cache:
-		fd, path = tempfile.mkstemp(dir=basedir)
-		with os.fdopen(fd, 'w') as tmp:
-			json.dump(validation_cache_dict, tmp)
-		os.rename(path, 'validation.cache')
+		if os.path.isfile(os.path.join(basedir, SIMEX_CACHE)):
+			with open(os.path.join(basedir, SIMEX_CACHE), 'r') as cachefile:
+				cache = json.load(cachefile)
+			cache["validation"] = validation_cache_dict
+			with open(os.path.join(basedir, SIMEX_CACHE), 'w') as cachefile:
+				json.dump(cache, cachefile)
 
 	if do_exit:
 		sys.exit(1)

--- a/tests/builds/experiments_ymls/build_examples/CMakeLists.txt
+++ b/tests/builds/experiments_ymls/build_examples/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.14)
+project(test_build_cpp)
+
+set(CMAKE_CXX_STANDARD 14)
+
+add_executable(test_build test_build.cpp)
+
+install(TARGETS test_build)

--- a/tests/builds/experiments_ymls/build_examples/experiments.yml
+++ b/tests/builds/experiments_ymls/build_examples/experiments.yml
@@ -1,0 +1,59 @@
+# This file contains example builds for git and non-git cases, and develop and non-dev cases.
+builds:
+  - name: git-gdsb
+    git: https://github.com/hu-macsy/graph-ds-benchmark.git
+    recursive-clone: true
+    
+    configure:
+      - args:
+        - 'cmake'
+        - '-GNinja'
+        # Experiments have been compiled using g++12.3. If you want to use your
+        # default c++ compiler, simply comment the following line.
+        # - '-DCMAKE_CXX_COMPILER=/opt/gcc-12.3@gcc8.5/bin/g++'
+        - '-DCMAKE_INSTALL_LIBDIR=lib'
+        - '-DCMAKE_INSTALL_PREFIX=@THIS_PREFIX_DIR@'
+        - '-DCMAKE_BUILD_TYPE=Release'
+        - '-DGDSB_MPI=On'
+        - '@THIS_SOURCE_DIR@'
+        - '-Dgdsb_DIR=@PREFIX_DIR_FOR:git-gdsb@/lib/cmake/git-gdsb'
+    compile:
+      - args: ['ninja']
+    install:
+      - args: ['ninja', 'install']
+  
+  - name: non-git-cpp
+    configure:
+      - args:
+          - 'cmake'
+          - '-DCMAKE_INSTALL_PREFIX=@BASE_DIR@'
+          - '@BASE_DIR@'
+    compile:
+       - args:
+          - 'make'
+    install:
+      - args:
+          - 'make'
+          - 'install'
+
+  - name: non-git-py
+
+revisions:
+  - name: git-non-dev-gdsb
+    build_version:
+      'git-gdsb': '027ee5048e8c00648185ee4321dab969a80396fe'
+
+  - name: git-dev-gdsb
+    develop: true
+    build_version:
+      'git-gdsb': ''
+
+  - name: non-git-dev-cpp
+    develop: true
+    build_version: 
+      'non-git-cpp': ''
+
+  - name: non-git-dev-py
+    develop: true
+    build_version: 
+      'non-git-py': ''  

--- a/tests/builds/experiments_ymls/build_examples/test_build.cpp
+++ b/tests/builds/experiments_ymls/build_examples/test_build.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+#include <vector>
+#include <fstream>
+#include <string>
+
+int main(int argc, char **argv){
+    std::cout<<"Cpp file has been build successfully.\n";
+}

--- a/tests/builds/test_builds.py
+++ b/tests/builds/test_builds.py
@@ -1,10 +1,16 @@
 
 import os
+import json
+import pytest
+import subprocess
 
 from simexpal import base
 from simexpal import build
+from simexpal import util
 
 file_dir = os.path.abspath(os.path.dirname(__file__))
+wanted_phases = [build.Phase.REGENERATE, build.Phase.COMPILE, build.Phase.CONFIGURE, build.Phase.INSTALL]
+wanted_cache_entries = [util.REGENERATED, util.COMPILED, util.CONFIGURED, util.INSTALLED]
 
 def test_simex_d_vcs_less():
     cfg = base.config_for_dir(file_dir + '/experiments_ymls/vcs_less/')
@@ -12,22 +18,32 @@ def test_simex_d_vcs_less():
     revision = cfg.get_revision('main')
     vcs_less_build = cfg.get_build('vcs-less', revision)
 
-    build.make_builds(cfg, revision, [vcs_less_build.info], ['vcs-less'], [build.Phase.INSTALL])
+    build.make_builds(cfg, revision, [vcs_less_build.info], ['main'], wanted_phases)
 
-    def check_files_in_dir(files, dir):
-        for file_name in files:
-            assert os.path.isfile(dir + file_name)
+    def check_cache_containment(cache_entries, dir, build_name):
+        assert os.path.isfile(os.path.join(dir, util.SIMEX_CACHE))
+        with open(os.path.join(dir, util.SIMEX_CACHE), "r") as cachefile:
+            cache = json.load(cachefile)
+            for cache_entry in cache_entries:
+                assert cache_entry in cache[build_name]
 
-    source_dir_files = ['/regenerated',
-                        '/regenerated.simexpal']
-    check_files_in_dir(source_dir_files, vcs_less_build.source_dir)
+    check_cache_containment(wanted_cache_entries, vcs_less_build._cfg.basedir, 'main')
 
-    compile_dir_files = ['/configured',
-                         '/configured.simexpal',
-                         '/compiled',
-                         '/compiled.simexpal',
-                         '/installed']
-    check_files_in_dir(compile_dir_files, vcs_less_build.compile_dir)
+def test_simex_develop_build():
+    cfg = base.config_for_dir(file_dir + '/experiments_ymls/build_examples/')
+    
+    def check_cache_containment(cache_entries, dir, build_name):
+        assert os.path.isfile(os.path.join(dir, util.SIMEX_CACHE))
+        with open(os.path.join(dir, util.SIMEX_CACHE), "r") as cachefile:
+            cache = json.load(cachefile)
+            for cache_entry in cache_entries:
+                assert cache_entry in cache[build_name]
+    
+    test_instances = [('git-non-dev-gdsb', 'git-gdsb'), ('git-dev-gdsb', 'git-gdsb'), ('non-git-dev-cpp', 'non-git-cpp'), ('non-git-dev-py', 'non-git-py')]
 
-    prefix_dir_files = ['/installed.simexpal']
-    check_files_in_dir(prefix_dir_files, vcs_less_build.prefix_dir)
+    for rev_name, build_name in test_instances:
+        revision = cfg.get_revision(rev_name)
+        git_example = cfg.get_build(build_name, revision)
+        build.make_builds(cfg, revision, [git_example.info], [build_name], wanted_phases)
+        check_cache_containment(wanted_cache_entries, git_example._cfg.basedir, rev_name)    
+


### PR DESCRIPTION
This PR refactors the build cache (which previously consisted of `status.cache`, `validation.cache` and various `.simexpal` files) into a unified caching structure referring to #169. 