### PR TITLE
add max_simultaneous experiment setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install libomp (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install libomp
       - name: Install ninja
         run: |
           python -m pip install ninja

--- a/docs/experiments.rst
+++ b/docs/experiments.rst
@@ -323,13 +323,14 @@ sbatch: ``--ntasks-per-node``, ``-c``, ``-N``
 When using a job scheduler like `Slurm <https://slurm.schedmd.com/overview.html>`_ it might be
 useful to run your software using different node/cpu settings.
 
-Currently, simexpal supports the following three ``sbatch`` parameters by using its own keywords in
+Currently, simexpal supports the following ``sbatch`` parameters by using its own keywords in
 the ``experiments.yml``:
 
-- ``procs_per_node``: number of tasks to invoke on each node (slurm: ``--ntasks-per-node=n``)
-- ``num_threads``:    number of cpus required per task (slurm: ``-c``, ``--cpus-per-task=ncpus``)
-- ``num_nodes``:      number of nodes on which to run (N = min[-max]) (slurm: ``-N``, ``--nodes=N``)
-- ``exclusive``:      boolean flag to run an experiment exclusively on specified computing resources (slurm: ``--exclusive``)
+- ``procs_per_node``:   number of tasks to invoke on each node (slurm: ``--ntasks-per-node=n``)
+- ``num_threads``:      number of cpus required per task (slurm: ``-c``, ``--cpus-per-task=ncpus``)
+- ``num_nodes``:        number of nodes on which to run (N = min[-max]) (slurm: ``-N``, ``--nodes=N``)
+- ``exclusive``:        boolean flag to run an experiment exclusively on specified computing resources (slurm: ``--exclusive``)
+- ``max_simultaneous``: limits the number of runs that are executed simultaneously (slurm: ``--array=X-Y%max_simultaneous``). Note that this setting is applied individually to each set of runs launched at once.
 
 .. code-block:: YAML
    :linenos:

--- a/simexpal/base.py
+++ b/simexpal/base.py
@@ -1126,6 +1126,10 @@ class ExperimentInfo:
 		return self._exp_yml.get('exclusive', None)
 
 	@property
+	def max_simultaneous(self):
+		return self._exp_yml.get('max_simultaneous', None)
+
+	@property
 	def slurm_args(self):
 		return self._exp_yml.get('slurm_args', [])
 
@@ -1234,6 +1238,10 @@ class Experiment:
 	@property
 	def is_exclusive(self):
 		return self.info.is_exclusive
+	
+	@property
+	def max_simultaneous(self):
+		return self.info.max_simultaneous
 
 	@property
 	def display_name(self):

--- a/simexpal/launch/slurm.py
+++ b/simexpal/launch/slurm.py
@@ -138,7 +138,11 @@ class SlurmLauncher(common.Launcher):
 				'-e', os.path.join(cfg.basedir, 'aux/_slurm/' + log_pattern + '.err')])
 
 		if use_array:
-			sbatch_args.append('--array=0-' + str(len(locked) - 1))
+			if experiment.max_simultaneous:
+				max_simultaneous = f"%{experiment.max_simultaneous}"
+			else:
+				max_simultaneous = ""
+			sbatch_args.append(f"--array=0-{len(locked) - 1}{max_simultaneous}")
 
 		# Add custom sbatch parameters of the user.
 		slurm_args = util.ensure_list_type(experiment.effective_slurm_args)

--- a/simexpal/schemes/experiments.json
+++ b/simexpal/schemes/experiments.json
@@ -56,6 +56,10 @@
 				"slurm_args": {"$ref": "#/definitions/str_or_str_list"},
 				"exclusive": {
 					"type": "boolean"
+				},
+				"max_simultaneous": {
+					"type": "integer",
+					"minimum": 1
 				}
 			}
 		}
@@ -449,6 +453,7 @@
 							"procs_per_node": {},
 							"num_threads": {},
 							"exclusive": {},
+							"max_simultaneous": {},
 							"slurm_args": {}
 						},
 						"additionalProperties": false

--- a/tests/builds/experiments_ymls/build_examples/experiments.yml
+++ b/tests/builds/experiments_ymls/build_examples/experiments.yml
@@ -58,7 +58,7 @@ builds:
 revisions:
   - name: git-gdsb
     build_version:
-      'test-git-gdsb': '3fe8b2e38d9de38b459e2e958df66577b77ccccf' #arbitrary commit hash to ensure determinism
+      'test-git-gdsb': '3fe8b2e38d9de38b459e2e958df66577b77ccccf' # fixed commit hash to ensure reproducibility
 
   - name: git-dev-gdsb
     develop: true

--- a/tests/builds/experiments_ymls/build_examples/experiments.yml
+++ b/tests/builds/experiments_ymls/build_examples/experiments.yml
@@ -1,9 +1,8 @@
 # This file contains example builds for git and non-git cases, and develop and non-dev cases.
 builds:
-  - name: test-git-gdsb
+  - name: test-git-gdsb-for-develop
     git: https://github.com/hu-macsy/graph-ds-benchmark.git
     recursive-clone: true
-    
     regenerate:
       - args: ['git', 'checkout', 'main']
       - args: ['git', 'pull']
@@ -11,9 +10,24 @@ builds:
       - args:
         - 'cmake'
         - '-GNinja'
-        # Experiments have been compiled using g++12.3. If you want to use your
-        # default c++ compiler, simply comment the following line.
-        # - '-DCMAKE_CXX_COMPILER=/opt/gcc-12.3@gcc8.5/bin/g++'
+        - '-DCMAKE_INSTALL_LIBDIR=lib'
+        - '-DCMAKE_INSTALL_PREFIX=@THIS_PREFIX_DIR@'
+        - '-DCMAKE_BUILD_TYPE=Release'
+        - '-DGDSB_MPI=Off'
+        - '@THIS_SOURCE_DIR@'
+        - '-Dgdsb_DIR=@PREFIX_DIR_FOR:test-git-gdsb-for-develop@/lib/cmake/test-git-gdsb-for-develop'
+    compile:
+      - args: ['ninja']
+    install:
+      - args: ['ninja', 'install']
+
+  - name: test-git-gdsb
+    git: https://github.com/hu-macsy/graph-ds-benchmark.git
+    recursive-clone: true
+    configure:
+      - args:
+        - 'cmake'
+        - '-GNinja'
         - '-DCMAKE_INSTALL_LIBDIR=lib'
         - '-DCMAKE_INSTALL_PREFIX=@THIS_PREFIX_DIR@'
         - '-DCMAKE_BUILD_TYPE=Release'
@@ -44,12 +58,12 @@ builds:
 revisions:
   - name: git-gdsb
     build_version:
-      'test-git-gdsb': '027ee5048e8c00648185ee4321dab969a80396fe' #arbitrary commit hash to ensure determinism
+      'test-git-gdsb': '3fe8b2e38d9de38b459e2e958df66577b77ccccf' #arbitrary commit hash to ensure determinism
 
   - name: git-dev-gdsb
     develop: true
     build_version:
-      'test-git-gdsb': ''
+      'test-git-gdsb-for-develop': ''
 
   - name: dev-cpp
     develop: true

--- a/tests/validation/experiments_ymls/invalid/experiments/max_simultaneous_str.yml
+++ b/tests/validation/experiments_ymls/invalid/experiments/max_simultaneous_str.yml
@@ -1,0 +1,5 @@
+experiments:
+  - name: foo
+    args: ['foo.py']
+    stdout: out
+    max_simultaneous: "wrong arg type"

--- a/tests/validation/experiments_ymls/valid/experiments/max_simultaneous.yml
+++ b/tests/validation/experiments_ymls/valid/experiments/max_simultaneous.yml
@@ -1,0 +1,5 @@
+experiments:
+  - name: foo
+    args: ['foo.py']
+    stdout: out
+    max_simultaneous: 2

--- a/tests/validation/test_experiments_yml.py
+++ b/tests/validation/test_experiments_yml.py
@@ -11,14 +11,17 @@ valid_experiments_ymls = ['../../examples/sorting/experiments.yml',
                           '../../examples/download_instances/experiments.yml',
                           'experiments_ymls/valid/instances/extra_args.yml',
                           'experiments_ymls/valid/variants/enum.yml',
-                          'experiments_ymls/valid/variants/range.yml']
+                          'experiments_ymls/valid/variants/range.yml',
+                          'experiments_ymls/valid/experiments/max_simultaneous.yml',
+                          ]
 
 invalid_experiments_ymls = ['experiments_ymls/invalid/top_level-additional_property.yml',
                             'experiments_ymls/invalid/instances/repo-invalid_value.yml',
                             'experiments_ymls/invalid/variants/enum_additional_property.yml',
                             'experiments_ymls/invalid/variants/range_additional_property.yml',
                             'experiments_ymls/invalid/variants/range_str_list.yml',
-                            'experiments_ymls/invalid/variants/steps_str_value.yml'
+                            'experiments_ymls/invalid/variants/steps_str_value.yml',
+                            'experiments_ymls/invalid/experiments/max_simultaneous_str.yml',
                             ]
 
 @pytest.mark.parametrize('rel_yml_path', valid_experiments_ymls)


### PR DESCRIPTION
This PR adds a new parameter to the `experiments` section. This parameter limits the maximum number of runs that slurm executes at once (extending the slurm array syntax that we already use: https://slurm.schedmd.com/job_array.html).

```yml
experiments:
  - name: foo
    args: ['foo.py']
    stdout: out
    max_simultaneous: 2
```

Use case: sometimes license limitations prevent us from running more than a specific number of experiments at once.

Limitation of this implementation: since this PR just extends the slurm array syntax, this setting only applies to a single launch. When launching multiple sets of experiments, the limit will be applied to each set individually. 