### PR TITLE
CI: Modernize (add slurm testing, remove EOL Python)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: koesterlab/setup-slurm-action@v1
+        if: matrix.os == 'ubuntu-latest'
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,17 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - "8888:3306"
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - uses: actions/checkout@v4
+      - uses: koesterlab/setup-slurm-action@v1
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,16 @@ jobs:
       - name: Run tests
         run: |
           pip install pytest==6.2.5
-          pytest
+          pytest -v
 
   build-and-test-macos:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python latest
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
       - name: Install libomp (macOS)
         run: |
           brew install libomp
@@ -54,7 +56,7 @@ jobs:
       - name: Run tests
         run: |
           pip install pytest==6.2.5
-          pytest -k "not slurm"
+          pytest -k "not slurm" -v
 
   # This job checks whether the current workflow is triggered by a new tag with the following form: INT.INT or INT.INT.INT (for example: 1.0, 1.0.1, ...)
   # The result is saved in a variable and used as a conditional variable when uploading packages.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: koesterlab/setup-slurm-action@v1
+        timeout-minutes: 5
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,11 @@ name: Run Python Test
 on: [push, pull_request]
 
 jobs:
-  build-and-test:
+  build-and-test-ubuntu:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     services:
       mysql:
         image: mysql:8.0
@@ -19,15 +18,30 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - uses: actions/checkout@v4
-      - name: install slurm (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        uses: koesterlab/setup-slurm-action@v1
+      - uses: koesterlab/setup-slurm-action@v1
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install ninja
+        run: |
+          python -m pip install ninja
+      - name: Install simexpal
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Run tests
+        run: |
+          pip install pytest==6.2.5
+          pytest
+
+  build-and-test-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python latest
+        uses: actions/setup-python@v5
       - name: Install libomp (macOS)
-        if: matrix.os == 'macos-latest'
         run: |
           brew install libomp
       - name: Install ninja
@@ -40,7 +54,7 @@ jobs:
       - name: Run tests
         run: |
           pip install pytest==6.2.5
-          pytest
+          pytest -k "not slurm"
 
   # This job checks whether the current workflow is triggered by a new tag with the following form: INT.INT or INT.INT.INT (for example: 1.0, 1.0.1, ...)
   # The result is saved in a variable and used as a conditional variable when uploading packages.
@@ -63,7 +77,7 @@ jobs:
     if: needs.check-release-tag.outputs.is-release == 'true' && github.repository == 'hu-macsy/simexpal'
     name: 'PyPi release upload'
     runs-on: ubuntu-20.04
-    needs: [build-and-test, check-release-tag]
+    needs: [build-and-test-ubuntu, check-release-tag]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build-and-test-ubuntu:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
     services:
       mysql:
@@ -40,10 +40,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.12
+      - name: Set up Python latest
         uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
       - name: Install libomp (macOS)
         run: |
           brew install libomp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,25 +8,62 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - "8888:3306"
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - uses: actions/checkout@v4
-      - uses: koesterlab/setup-slurm-action@v1
-        timeout-minutes: 5
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install ninja
+      - name: Install prerequisites
+        shell: bash -e {0}
         run: |
+          ansible-galaxy role install https://github.com/galaxyproject/ansible-slurm/archive/1.0.1.tar.gz
+          sudo apt-get update
           pip install ninja
+      - name: Setup ansible playbook for slurm
+        uses: 1arp/create-a-file-action@0.2
+        with:
+          file: slurm-playbook.yml
+          content: |
+            - name: Slurm all in One
+              hosts: localhost
+              roles:
+                - role: 1.0.1
+                  become: true
+              vars:
+                  slurm_upgrade: true
+                  slurm_roles: ['controller', 'exec']
+                  slurm_config_dir: /etc/slurm
+                  slurm_config:
+                      ClusterName: cluster
+                      SlurmctldLogFile: /var/log/slurm/slurmctld.log
+                      SlurmctldPidFile: /run/slurmctld.pid
+                      SlurmdLogFile: /var/log/slurm/slurmd.log
+                      SlurmdPidFile: /run/slurmd.pid
+                      SlurmdSpoolDir: /tmp/slurmd # the default /var/lib/slurm/slurmd does not work because of noexec mounting in github actions
+                      StateSaveLocation: /var/lib/slurm/slurmctld
+                      SelectType: select/cons_tres
+                  slurm_create_user: yes
+                  slurm_nodes:
+                      - name: localhost
+                        State: UNKNOWN
+                        Sockets: 1
+                        CoresPerSocket: 2
+                        RealMemory: 2000
+                  slurm_user:
+                      comment: "Slurm Workload Manager"
+                      gid: 1002
+                      group: slurm
+                      home: "/var/lib/slurm"
+                      name: slurm
+                      shell: "/bin/bash"
+                      uid: 1002
+      - name: Setup slurm
+        shell: bash -e {0}
+        run: |
+          mkdir -p /tmp/1002-runtime # work around podman issue (https://github.com/containers/podman/issues/13338)
+          echo XDG_RUNTIME_DIR=/tmp/1002-runtime >> $GITHUB_ENV
+          ansible-playbook slurm-playbook.yml || (journalctl -xe && exit 1)
       - name: Install simexpal
         run: |
           pip install .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - uses: actions/checkout@v4
-      - uses: koesterlab/setup-slurm-action@v1
-        if: matrix.os == 'ubuntu-latest'
+      - if: matrix.os == 'ubuntu-latest'
+        uses: koesterlab/setup-slurm-action@v1
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - uses: actions/checkout@v4
-      - if: matrix.os == 'ubuntu-latest'
+      - name: install slurm (ubuntu)
+        if: matrix.os == 'ubuntu-latest'
         uses: koesterlab/setup-slurm-action@v1
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Python latest
         uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
       - name: Install libomp (macOS)
         run: |
           brew install libomp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run tests
         run: |
           pip install pytest==6.2.5
-          pytest -v
+          pytest
 
   build-and-test-macos:
     runs-on: macos-latest
@@ -56,7 +56,7 @@ jobs:
       - name: Run tests
         run: |
           pip install pytest==6.2.5
-          pytest -k "not slurm" -v
+          pytest -k "not slurm"
 
   # This job checks whether the current workflow is triggered by a new tag with the following form: INT.INT or INT.INT.INT (for example: 1.0, 1.0.1, ...)
   # The result is saved in a variable and used as a conditional variable when uploading packages.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install ninja
         run: |
-          python -m pip install ninja
+          pip install ninja
       - name: Install simexpal
         run: |
-          python -m pip install --upgrade pip
           pip install .
       - name: Run tests
         run: |
-          pip install pytest==6.2.5
+          pip install pytest
           pytest
 
   build-and-test-macos:
@@ -47,14 +46,13 @@ jobs:
           brew install libomp
       - name: Install ninja
         run: |
-          python -m pip install ninja
+          pip install ninja
       - name: Install simexpal
         run: |
-          python -m pip install --upgrade pip
           pip install .
       - name: Run tests
         run: |
-          pip install pytest==6.2.5
+          pip install pytest
           pytest -k "not slurm"
 
   # This job checks whether the current workflow is triggered by a new tag with the following form: INT.INT or INT.INT.INT (for example: 1.0, 1.0.1, ...)
@@ -87,7 +85,6 @@ jobs:
           python-version: 3.11
       - name: Create wheel
         run: |
-          python -m pip install --upgrade pip
           pip install wheel
           python3 -m pip wheel ./ --wheel-dir=./dist --no-deps
       - name: Create source package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build-and-test-ubuntu:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     runs-on: ubuntu-latest
     services:
       mysql:

--- a/tests/cli/test_experiments.py
+++ b/tests/cli/test_experiments.py
@@ -1,4 +1,3 @@
-
 import os
 import pytest
 import subprocess
@@ -18,7 +17,23 @@ def test_simex_e_launch_fork(rel_yml_path):
 
     assert ret_code == 0
 
-@pytest.mark.parametrize('rel_yml_path', yml_dirs)
+
+@pytest.mark.parametrize("rel_yml_path", yml_dirs)
+def test_simex_e_launch_slurm(rel_yml_path):
+    # Make sure that the needed instances are installed.
+    # The main test follows afterwards.
+    cwd = file_dir + rel_yml_path
+    ret_code = subprocess.check_call(["simex", "i", "install"], cwd=cwd)
+    assert ret_code == 0
+
+    ret_code = subprocess.check_call(
+        ["simex", "e", "launch", "--launch-through=slurm"], cwd=cwd
+    )
+
+    assert ret_code == 0
+
+
+@pytest.mark.parametrize("rel_yml_path", yml_dirs)
 def test_simex_e_purge_all(rel_yml_path):
     cwd = file_dir + rel_yml_path
     ret_code = subprocess.check_call(['simex', 'e', 'purge', '--all', '-f'], cwd=cwd)

--- a/tests/cli/test_experiments.py
+++ b/tests/cli/test_experiments.py
@@ -5,21 +5,10 @@ import subprocess
 file_dir = os.path.abspath(os.path.dirname(__file__))
 yml_dirs = ['/../../examples/sorting/']  # List of directories that should be tested.
 
-@pytest.mark.parametrize('rel_yml_path', yml_dirs)
-def test_simex_e_launch_fork(rel_yml_path):
-    # Make sure that the needed instances are installed.
-    # The main test follows afterwards.
-    cwd = file_dir + rel_yml_path
-    ret_code = subprocess.check_call(['simex', 'i', 'install'], cwd=cwd)
-    assert ret_code == 0
 
-    ret_code = subprocess.check_call(['simex', 'e', 'launch', '--launch-through=fork'], cwd=cwd)
-
-    assert ret_code == 0
-
-
+@pytest.mark.parametrize("launcher", ["fork", "slurm"])
 @pytest.mark.parametrize("rel_yml_path", yml_dirs)
-def test_simex_e_launch_slurm(rel_yml_path):
+def test_simex_e_launch(launcher, rel_yml_path):
     # Make sure that the needed instances are installed.
     # The main test follows afterwards.
     cwd = file_dir + rel_yml_path
@@ -27,7 +16,7 @@ def test_simex_e_launch_slurm(rel_yml_path):
     assert ret_code == 0
 
     ret_code = subprocess.check_call(
-        ["simex", "e", "launch", "--launch-through=slurm"], cwd=cwd
+        ["simex", "e", "launch", f"--launch-through={launcher}"], cwd=cwd
     )
 
     assert ret_code == 0


### PR DESCRIPTION
Adds slurm to ubuntu ci jobs. With this PR, the test that previously tested the fork launcher now also tests the same experiments with the slurm launcher.